### PR TITLE
v2 review fixes

### DIFF
--- a/py_clob_client_v2/client.py
+++ b/py_clob_client_v2/client.py
@@ -720,9 +720,9 @@ class ClobClient:
                 order_args.builder_code = self.builder_config.builder_code
 
         builder_code = getattr(order_args, "builder_code", BYTES32_ZERO)
-        self.__ensure_builder_fee_rate_cached(builder_code)
 
         if order_args.side == "BUY" and order_args.user_usdc_balance:
+            self.__ensure_builder_fee_rate_cached(builder_code)
             builder_taker_fee_rate = (
                 self.__builder_fee_rates[builder_code].taker
                 if builder_code and builder_code != BYTES32_ZERO and builder_code in self.__builder_fee_rates
@@ -982,7 +982,7 @@ class ClobClient:
                 taker=result.get("builder_taker_fee_rate_bps", 0) / BUILDER_FEES_BPS,
             )
         except Exception:
-            self.__builder_fee_rates[builder_code] = BuilderFeeRate(maker=0, taker=0)
+            logging.warning("failed to fetch builder fee rate for %s, will retry on next order", builder_code)
 
     def __ensure_market_info_cached(self, token_id: str):
         if token_id in self.__market_info_fetched:

--- a/py_clob_client_v2/client.py
+++ b/py_clob_client_v2/client.py
@@ -970,11 +970,14 @@ class ClobClient:
             return
         if builder_code in self.__builder_fee_rates:
             return
-        result = self._get(f"{self.host}{GET_BUILDER_FEE_RATE}{builder_code}")
-        self.__builder_fee_rates[builder_code] = BuilderFeeRate(
-            maker=result.get("builder_maker_fee_rate_bps", 0) / BUILDER_FEES_BPS,
-            taker=result.get("builder_taker_fee_rate_bps", 0) / BUILDER_FEES_BPS,
-        )
+        try:
+            result = self._get(f"{self.host}{GET_BUILDER_FEE_RATE}{builder_code}")
+            self.__builder_fee_rates[builder_code] = BuilderFeeRate(
+                maker=result.get("builder_maker_fee_rate_bps", 0) / BUILDER_FEES_BPS,
+                taker=result.get("builder_taker_fee_rate_bps", 0) / BUILDER_FEES_BPS,
+            )
+        except Exception:
+            self.__builder_fee_rates[builder_code] = BuilderFeeRate(maker=0, taker=0)
 
     def __ensure_market_info_cached(self, token_id: str):
         if token_id in self.__fee_infos:

--- a/py_clob_client_v2/client.py
+++ b/py_clob_client_v2/client.py
@@ -156,7 +156,6 @@ class ClobClient:
         self.__tick_sizes: dict = {}
         self.__neg_risk: dict = {}
         self.__fee_infos: dict = {}
-        self.__market_info_fetched: set = set()
         self.__builder_fee_rates: dict = {}
         self.__token_condition_map: dict = {}
         self.__cached_version: Optional[int] = None
@@ -286,13 +285,10 @@ class ClobClient:
             self.__neg_risk[token_id] = result["nr"]
 
             fd = result.get("fd") or {}
-            fi = self.__fee_infos.get(token_id, FeeInfo())
-            if fd.get("r") is not None:
-                fi.rate = fd["r"]
-            if fd.get("e") is not None:
-                fi.exponent = fd["e"]
-            self.__fee_infos[token_id] = fi
-            self.__market_info_fetched.add(token_id)
+            self.__fee_infos[token_id] = FeeInfo(
+                rate=fd.get("r", 0.0),
+                exponent=fd.get("e", 0.0),
+            )
 
         return result
 
@@ -336,30 +332,24 @@ class ClobClient:
         return self.__neg_risk[token_id]
 
     def get_fee_rate_bps(self, token_id: str) -> float:
-        fi = self.__fee_infos.get(token_id)
-        if fi is not None and fi.rate is not None:
-            return fi.rate
+        if token_id in self.__fee_infos:
+            return self.__fee_infos[token_id].rate
 
         if token_id in self.__token_condition_map:
             self.get_clob_market_info(self.__token_condition_map[token_id])
-            rate = self.__fee_infos[token_id].rate
-            return rate if rate is not None else 0.0
+            return self.__fee_infos[token_id].rate
 
         result = self._get(
             f"{self.host}{GET_FEE_RATE}", params={"token_id": token_id}
         )
-        fi = self.__fee_infos.get(token_id) or FeeInfo()
-        fi.rate = result["base_fee"]
-        self.__fee_infos[token_id] = fi
-        return fi.rate
+        self.__fee_infos[token_id] = FeeInfo(rate=result["base_fee"], exponent=0.0)
+        return self.__fee_infos[token_id].rate
 
     def get_fee_exponent(self, token_id: str) -> float:
-        fi = self.__fee_infos.get(token_id)
-        if fi is not None and fi.exponent is not None:
-            return fi.exponent
+        if token_id in self.__fee_infos:
+            return self.__fee_infos[token_id].exponent
         self.__ensure_market_info_cached(token_id)
-        exponent = self.__fee_infos.get(token_id, FeeInfo()).exponent
-        return exponent if exponent is not None else 0.0
+        return self.__fee_infos[token_id].exponent
 
     def get_midpoint(self, token_id: str):
         return self._get(f"{self.host}{GET_MIDPOINT}", params={"token_id": token_id})
@@ -985,7 +975,7 @@ class ClobClient:
             logging.warning("failed to fetch builder fee rate for %s, will retry on next order", builder_code)
 
     def __ensure_market_info_cached(self, token_id: str):
-        if token_id in self.__market_info_fetched:
+        if token_id in self.__fee_infos:
             return
 
         if token_id not in self.__token_condition_map:

--- a/py_clob_client_v2/client.py
+++ b/py_clob_client_v2/client.py
@@ -157,6 +157,7 @@ class ClobClient:
         self.__tick_sizes: dict = {}
         self.__neg_risk: dict = {}
         self.__fee_infos: dict = {}
+        self.__market_info_fetched: set = set()
         self.__builder_fee_rates: dict = {}
         self.__token_condition_map: dict = {}
         self.__cached_version: Optional[int] = None
@@ -292,6 +293,7 @@ class ClobClient:
             if fd.get("e") is not None:
                 fi.exponent = fd["e"]
             self.__fee_infos[token_id] = fi
+            self.__market_info_fetched.add(token_id)
 
         return result
 
@@ -335,8 +337,9 @@ class ClobClient:
         return self.__neg_risk[token_id]
 
     def get_fee_rate_bps(self, token_id: str) -> float:
-        if token_id in self.__fee_infos:
-            return self.__fee_infos[token_id].rate
+        fi = self.__fee_infos.get(token_id)
+        if fi is not None and fi.rate is not None:
+            return fi.rate
 
         if token_id in self.__token_condition_map:
             self.get_clob_market_info(self.__token_condition_map[token_id])
@@ -345,14 +348,15 @@ class ClobClient:
         result = self._get(
             f"{self.host}{GET_FEE_RATE}", params={"token_id": token_id}
         )
-        fi = self.__fee_infos.get(token_id, FeeInfo())
+        fi = self.__fee_infos.get(token_id) or FeeInfo()
         fi.rate = result["base_fee"]
         self.__fee_infos[token_id] = fi
         return fi.rate
 
     def get_fee_exponent(self, token_id: str) -> float:
-        if token_id in self.__fee_infos:
-            return self.__fee_infos[token_id].exponent
+        fi = self.__fee_infos.get(token_id)
+        if fi is not None and fi.exponent is not None:
+            return fi.exponent
         self.__ensure_market_info_cached(token_id)
         return self.__fee_infos[token_id].exponent
 
@@ -723,13 +727,13 @@ class ClobClient:
                 if builder_code and builder_code != BYTES32_ZERO and builder_code in self.__builder_fee_rates
                 else 0
             )
-            fi = self.__fee_infos.get(token_id, FeeInfo())
+            fi = self.__fee_infos.get(token_id) or FeeInfo()
             order_args.amount = adjust_market_buy_amount(
                 order_args.amount,
                 order_args.user_usdc_balance,
                 order_args.price,
-                fi.rate,
-                fi.exponent,
+                fi.rate or 0.0,
+                fi.exponent or 0.0,
                 builder_taker_fee_rate,
             )
 
@@ -980,7 +984,7 @@ class ClobClient:
             self.__builder_fee_rates[builder_code] = BuilderFeeRate(maker=0, taker=0)
 
     def __ensure_market_info_cached(self, token_id: str):
-        if token_id in self.__fee_infos:
+        if token_id in self.__market_info_fetched:
             return
 
         if token_id not in self.__token_condition_map:

--- a/py_clob_client_v2/client.py
+++ b/py_clob_client_v2/client.py
@@ -6,7 +6,6 @@ from .clob_types import (
     ApiCreds,
     BalanceAllowanceParams,
     BookParams,
-    BuilderCode,
     BuilderConfig,
     BuilderFeeRate,
     BuilderTradeParams,
@@ -343,7 +342,8 @@ class ClobClient:
 
         if token_id in self.__token_condition_map:
             self.get_clob_market_info(self.__token_condition_map[token_id])
-            return self.__fee_infos[token_id].rate
+            rate = self.__fee_infos[token_id].rate
+            return rate if rate is not None else 0.0
 
         result = self._get(
             f"{self.host}{GET_FEE_RATE}", params={"token_id": token_id}
@@ -358,7 +358,8 @@ class ClobClient:
         if fi is not None and fi.exponent is not None:
             return fi.exponent
         self.__ensure_market_info_cached(token_id)
-        return self.__fee_infos[token_id].exponent
+        exponent = self.__fee_infos.get(token_id, FeeInfo()).exponent
+        return exponent if exponent is not None else 0.0
 
     def get_midpoint(self, token_id: str):
         return self._get(f"{self.host}{GET_MIDPOINT}", params={"token_id": token_id})

--- a/py_clob_client_v2/client.py
+++ b/py_clob_client_v2/client.py
@@ -6,11 +6,14 @@ from .clob_types import (
     ApiCreds,
     BalanceAllowanceParams,
     BookParams,
+    BuilderCode,
     BuilderConfig,
+    BuilderFeeRate,
     BuilderTradeParams,
     CreateOrderOptions,
     DropNotificationParams,
     EarningsParams,
+    FeeInfo,
     MarketOrderArgsV2,
     OpenOrderParams,
     OrderArgsV2,
@@ -53,6 +56,7 @@ from .endpoints import (
     GET_API_KEYS,
     GET_BALANCE_ALLOWANCE,
     GET_BUILDER_API_KEYS,
+    GET_BUILDER_FEE_RATE,
     GET_BUILDER_TRADES,
     GET_CLOB_MARKET,
     GET_EARNINGS_FOR_USER_FOR_DAY,
@@ -152,8 +156,7 @@ class ClobClient:
         # Caches
         self.__tick_sizes: dict = {}
         self.__neg_risk: dict = {}
-        self.__fee_rates: dict = {}
-        self.__fee_exponents: dict = {}
+        self.__fee_infos: dict = {}
         self.__builder_fee_rates: dict = {}
         self.__token_condition_map: dict = {}
         self.__cached_version: Optional[int] = None
@@ -283,16 +286,12 @@ class ClobClient:
             self.__neg_risk[token_id] = result["nr"]
 
             fd = result.get("fd") or {}
-            self.__fee_rates[token_id] = fd.get("r", 0)
-            self.__fee_exponents[token_id] = fd.get("e", 0)
-
-            mbf = result.get("mbf")
-            tbf = result.get("tbf")
-            if mbf is not None or tbf is not None:
-                self.__builder_fee_rates[token_id] = {
-                    "maker": (mbf or 0) / BUILDER_FEES_BPS,
-                    "taker": (tbf or 0) / BUILDER_FEES_BPS,
-                }
+            fi = self.__fee_infos.get(token_id, FeeInfo())
+            if fd.get("r") is not None:
+                fi.rate = fd["r"]
+            if fd.get("e") is not None:
+                fi.exponent = fd["e"]
+            self.__fee_infos[token_id] = fi
 
         return result
 
@@ -335,25 +334,27 @@ class ClobClient:
         self.__neg_risk[token_id] = result["neg_risk"]
         return self.__neg_risk[token_id]
 
-    def get_fee_rate_bps(self, token_id: str) -> int:
-        if token_id in self.__fee_rates:
-            return self.__fee_rates[token_id]
+    def get_fee_rate_bps(self, token_id: str) -> float:
+        if token_id in self.__fee_infos:
+            return self.__fee_infos[token_id].rate
 
         if token_id in self.__token_condition_map:
             self.get_clob_market_info(self.__token_condition_map[token_id])
-            return self.__fee_rates[token_id]
+            return self.__fee_infos[token_id].rate
 
         result = self._get(
             f"{self.host}{GET_FEE_RATE}", params={"token_id": token_id}
         )
-        self.__fee_rates[token_id] = result["base_fee"]
-        return self.__fee_rates[token_id]
+        fi = self.__fee_infos.get(token_id, FeeInfo())
+        fi.rate = result["base_fee"]
+        self.__fee_infos[token_id] = fi
+        return fi.rate
 
-    def get_fee_exponent(self, token_id: str) -> int:
-        if token_id in self.__fee_exponents:
-            return self.__fee_exponents[token_id]
+    def get_fee_exponent(self, token_id: str) -> float:
+        if token_id in self.__fee_infos:
+            return self.__fee_infos[token_id].exponent
         self.__ensure_market_info_cached(token_id)
-        return self.__fee_exponents[token_id]
+        return self.__fee_infos[token_id].exponent
 
     def get_midpoint(self, token_id: str):
         return self._get(f"{self.host}{GET_MIDPOINT}", params={"token_id": token_id})
@@ -713,20 +714,22 @@ class ClobClient:
             if not getattr(order_args, "builder_code", None) or order_args.builder_code == BYTES32_ZERO:
                 order_args.builder_code = self.builder_config.builder_code
 
-        # Fee-adjusted amount for market buy orders
+        builder_code = getattr(order_args, "builder_code", BYTES32_ZERO)
+        self.__ensure_builder_fee_rate_cached(builder_code)
+
         if order_args.side == "BUY" and order_args.user_usdc_balance:
-            builder_code = getattr(order_args, "builder_code", BYTES32_ZERO)
             builder_taker_fee_rate = (
-                self.__builder_fee_rates.get(token_id, {}).get("taker", 0)
-                if builder_code and builder_code != BYTES32_ZERO
+                self.__builder_fee_rates[builder_code].taker
+                if builder_code and builder_code != BYTES32_ZERO and builder_code in self.__builder_fee_rates
                 else 0
             )
+            fi = self.__fee_infos.get(token_id, FeeInfo())
             order_args.amount = adjust_market_buy_amount(
                 order_args.amount,
                 order_args.user_usdc_balance,
                 order_args.price,
-                self.__fee_rates.get(token_id, 0),
-                self.__fee_exponents.get(token_id, 0),
+                fi.rate,
+                fi.exponent,
                 builder_taker_fee_rate,
             )
 
@@ -962,8 +965,19 @@ class ClobClient:
         self.__cached_version = self.get_version()
         return self.__cached_version
 
+    def __ensure_builder_fee_rate_cached(self, builder_code: str):
+        if not builder_code or builder_code == BYTES32_ZERO:
+            return
+        if builder_code in self.__builder_fee_rates:
+            return
+        result = self._get(f"{self.host}{GET_BUILDER_FEE_RATE}{builder_code}")
+        self.__builder_fee_rates[builder_code] = BuilderFeeRate(
+            maker=result.get("builder_maker_fee_rate_bps", 0) / BUILDER_FEES_BPS,
+            taker=result.get("builder_taker_fee_rate_bps", 0) / BUILDER_FEES_BPS,
+        )
+
     def __ensure_market_info_cached(self, token_id: str):
-        if token_id in self.__fee_rates and token_id in self.__fee_exponents:
+        if token_id in self.__fee_infos:
             return
 
         if token_id not in self.__token_condition_map:

--- a/py_clob_client_v2/clob_types.py
+++ b/py_clob_client_v2/clob_types.py
@@ -327,14 +327,6 @@ class BuilderFeeRate:
 
 
 @dataclass
-class BuilderCode:
-    code: str = ""
-    builder_maker_fee_rate_bps: int = 0
-    builder_taker_fee_rate_bps: int = 0
-    enabled: bool = False
-
-
-@dataclass
 class ClobToken:
     """A YES or NO token in a CLOB market"""
 

--- a/py_clob_client_v2/clob_types.py
+++ b/py_clob_client_v2/clob_types.py
@@ -315,6 +315,26 @@ class FeeDetails:
 
 
 @dataclass
+class FeeInfo:
+    rate: float = 0.0
+    exponent: float = 0.0
+
+
+@dataclass
+class BuilderFeeRate:
+    maker: float = 0.0
+    taker: float = 0.0
+
+
+@dataclass
+class BuilderCode:
+    code: str = ""
+    builder_maker_fee_rate_bps: int = 0
+    builder_taker_fee_rate_bps: int = 0
+    enabled: bool = False
+
+
+@dataclass
 class ClobToken:
     """A YES or NO token in a CLOB market"""
 
@@ -341,11 +361,11 @@ class MarketDetails:
     fee_details: Optional[FeeDetails] = None
     """Platform fee details"""
 
-    builder_maker_fee: Optional[float] = None
-    """Builder maker fee rate"""
+    maker_base_fee: Optional[float] = None
+    """V1 maker base fee rate (from mbf field); not used for builder fee rate calculation"""
 
-    builder_taker_fee: Optional[float] = None
-    """Builder taker fee rate"""
+    taker_base_fee: Optional[float] = None
+    """V1 taker base fee rate (from tbf field); not used for builder fee rate calculation"""
 
 
 @dataclass

--- a/py_clob_client_v2/clob_types.py
+++ b/py_clob_client_v2/clob_types.py
@@ -362,10 +362,10 @@ class MarketDetails:
     """Platform fee details"""
 
     maker_base_fee: Optional[float] = None
-    """V1 maker base fee rate (from mbf field); not used for builder fee rate calculation"""
+    """V1 maker base fee rate (from mbf field)"""
 
     taker_base_fee: Optional[float] = None
-    """V1 taker base fee rate (from tbf field); not used for builder fee rate calculation"""
+    """V1 taker base fee rate (from tbf field)"""
 
 
 @dataclass

--- a/py_clob_client_v2/clob_types.py
+++ b/py_clob_client_v2/clob_types.py
@@ -316,8 +316,8 @@ class FeeDetails:
 
 @dataclass
 class FeeInfo:
-    rate: Optional[float] = None
-    exponent: Optional[float] = None
+    rate: float = 0.0
+    exponent: float = 0.0
 
 
 @dataclass

--- a/py_clob_client_v2/clob_types.py
+++ b/py_clob_client_v2/clob_types.py
@@ -316,8 +316,8 @@ class FeeDetails:
 
 @dataclass
 class FeeInfo:
-    rate: float = 0.0
-    exponent: float = 0.0
+    rate: Optional[float] = None
+    exponent: Optional[float] = None
 
 
 @dataclass

--- a/py_clob_client_v2/endpoints.py
+++ b/py_clob_client_v2/endpoints.py
@@ -78,6 +78,7 @@ GET_REWARDS_EARNINGS_PERCENTAGES = "/rewards/user/markets"
 # Builder endpoints
 POST_HEARTBEAT = "/v1/heartbeats"
 GET_BUILDER_TRADES = "/builder/trades"
+GET_BUILDER_FEE_RATE = "/fees/builder-fees/"
 
 # RFQ Endpoints
 CREATE_RFQ_REQUEST = "/rfq/request"

--- a/py_clob_client_v2/utilities.py
+++ b/py_clob_client_v2/utilities.py
@@ -57,13 +57,13 @@ def adjust_market_buy_amount(
     builder_taker_fee_rate: float = 0,
 ) -> float:
     """Return fee-adjusted amount for a market buy, or the original amount if balance is sufficient."""
-    platform_fee_rate = fee_rate * (price * (1 - price)) ** fee_exponent
-
     d_amount = Decimal(str(amount))
     d_price = Decimal(str(price))
     d_balance = Decimal(str(user_usdc_balance))
-    d_pfr = Decimal(str(platform_fee_rate))
+    d_fee_rate = Decimal(str(fee_rate))
+    d_fee_exponent = Decimal(str(fee_exponent))
     d_btr = Decimal(str(builder_taker_fee_rate))
+    d_pfr = d_fee_rate * (d_price * (Decimal("1") - d_price)) ** d_fee_exponent
 
     platform_fee = d_amount / d_price * d_pfr
     total_cost = d_amount + platform_fee + d_amount * d_btr

--- a/py_clob_client_v2/utilities.py
+++ b/py_clob_client_v2/utilities.py
@@ -63,7 +63,8 @@ def adjust_market_buy_amount(
     d_fee_rate = Decimal(str(fee_rate))
     d_fee_exponent = Decimal(str(fee_exponent))
     d_btr = Decimal(str(builder_taker_fee_rate))
-    d_pfr = d_fee_rate * (d_price * (Decimal("1") - d_price)) ** d_fee_exponent
+    base = float(d_price * (Decimal("1") - d_price))
+    d_pfr = d_fee_rate * Decimal(str(base ** float(d_fee_exponent)))
 
     platform_fee = d_amount / d_price * d_pfr
     total_cost = d_amount + platform_fee + d_amount * d_btr

--- a/py_clob_client_v2/utilities.py
+++ b/py_clob_client_v2/utilities.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+from decimal import Decimal
 
 from .clob_types import OrderBookSummary, OrderSummary, TickSize
 
@@ -52,15 +53,23 @@ def adjust_market_buy_amount(
     user_usdc_balance: float,
     price: float,
     fee_rate: float,
-    fee_exponent: int,
+    fee_exponent: float,
     builder_taker_fee_rate: float = 0,
 ) -> float:
     """Return fee-adjusted amount for a market buy, or the original amount if balance is sufficient."""
     platform_fee_rate = fee_rate * (price * (1 - price)) ** fee_exponent
-    platform_fee = (amount / price) * platform_fee_rate
-    total_cost = amount + platform_fee + amount * builder_taker_fee_rate
-    if user_usdc_balance <= total_cost:
-        return user_usdc_balance / (1 + platform_fee_rate / price + builder_taker_fee_rate)
+
+    d_amount = Decimal(str(amount))
+    d_price = Decimal(str(price))
+    d_balance = Decimal(str(user_usdc_balance))
+    d_pfr = Decimal(str(platform_fee_rate))
+    d_btr = Decimal(str(builder_taker_fee_rate))
+
+    platform_fee = d_amount / d_price * d_pfr
+    total_cost = d_amount + platform_fee + d_amount * d_btr
+    if d_balance <= total_cost:
+        divisor = Decimal("1") + d_pfr / d_price + d_btr
+        return float(d_balance / divisor)
     return amount
 
 

--- a/tests/test_client_fee_cache.py
+++ b/tests/test_client_fee_cache.py
@@ -1,9 +1,11 @@
 """
 Tests for FeeInfo cache correctness in ClobClient.
 
-Regression coverage for the bug where get_fee_rate_bps (GET_FEE_RATE fallback)
-stored a FeeInfo with only rate set, causing get_fee_exponent to see the key and
-return exponent=None (formerly 0.0) without ever fetching real market info.
+Aligned with TypeScript clob-client-v2 behavior:
+- getClobMarketInfo always sets feeInfos[tokenId] = FeeInfo(rate=fd?.r ?? 0, exponent=fd?.e ?? 0)
+- Cache presence check is `token_id in __fee_infos` (not None-checking values)
+- _ensureMarketInfoCached returns early if token_id in __fee_infos
+- GET_FEE_RATE fallback sets FeeInfo(rate=X, exponent=0) — overwrites
 """
 
 from unittest.mock import MagicMock, patch
@@ -24,20 +26,18 @@ def _make_client() -> ClobClient:
 
 
 def _inject_market_info(client: ClobClient, token_id: str, rate: float, exponent: float):
-    """Simulate get_clob_market_info populating all cache fields."""
-    fi = FeeInfo(rate=rate, exponent=exponent)
-    client._ClobClient__fee_infos[token_id] = fi
-    client._ClobClient__market_info_fetched.add(token_id)
+    """Simulate getClobMarketInfo populating all cache fields."""
+    client._ClobClient__fee_infos[token_id] = FeeInfo(rate=rate, exponent=exponent)
     client._ClobClient__tick_sizes[token_id] = "0.01"
     client._ClobClient__neg_risk[token_id] = False
     client._ClobClient__token_condition_map[token_id] = CONDITION_ID
 
 
-class TestFeeInfoSentinels:
-    def test_fee_info_defaults_are_none(self):
+class TestFeeInfoDefaults:
+    def test_fee_info_defaults_are_zero(self):
         fi = FeeInfo()
-        assert fi.rate is None
-        assert fi.exponent is None
+        assert fi.rate == 0.0
+        assert fi.exponent == 0.0
 
     def test_fee_info_explicit_values(self):
         fi = FeeInfo(rate=0.02, exponent=2.0)
@@ -51,61 +51,55 @@ class TestGetFeeRateBps:
         _inject_market_info(client, TOKEN_ID, rate=0.02, exponent=2.0)
         assert client.get_fee_rate_bps(TOKEN_ID) == 0.02
 
-    def test_rate_only_entry_does_not_satisfy_cache_check(self):
-        """A FeeInfo with only rate set must NOT prevent fetching exponent later."""
+    def test_cache_hit_any_fee_info_entry(self):
+        """Any entry in __fee_infos satisfies the cache check."""
         client = _make_client()
-        # Simulate the GET_FEE_RATE fallback: rate stored, exponent still None
-        client._ClobClient__fee_infos[TOKEN_ID] = FeeInfo(rate=0.03, exponent=None)
-
-        # get_fee_rate_bps should still return the cached rate
+        client._ClobClient__fee_infos[TOKEN_ID] = FeeInfo(rate=0.03, exponent=0.0)
         assert client.get_fee_rate_bps(TOKEN_ID) == 0.03
 
-    def test_get_fee_rate_fallback_does_not_block_exponent_fetch(self):
-        """
-        Core regression: after get_fee_rate_bps uses GET_FEE_RATE fallback,
-        get_fee_exponent must still trigger __ensure_market_info_cached.
-        """
+    def test_get_fee_rate_via_condition_map(self):
+        """Falls through to getClobMarketInfo when token is in condition_map but not fee_infos."""
         client = _make_client()
-
-        # Simulate GET_FEE_RATE fallback storing rate-only FeeInfo
-        client._ClobClient__fee_infos[TOKEN_ID] = FeeInfo(rate=0.03, exponent=None)
-        # token is NOT in __market_info_fetched
+        client._ClobClient__token_condition_map[TOKEN_ID] = CONDITION_ID
 
         clob_market_response = {
             "t": [{"t": TOKEN_ID}],
             "mts": "0.01",
             "nr": False,
-            "fd": {"r": 0.03, "e": 2.0},
-            "mbf": 0,
-            "tbf": 0,
+            "fd": {"r": 0.025, "e": 1.0},
         }
+        with patch.object(client, "_get", return_value=clob_market_response):
+            rate = client.get_fee_rate_bps(TOKEN_ID)
 
-        with patch.object(client, "_get", return_value=clob_market_response) as mock_get, \
-             patch.object(client, "_ClobClient__token_condition_map", {TOKEN_ID: CONDITION_ID}):
-            exponent = client.get_fee_exponent(TOKEN_ID)
-
-        assert exponent == 2.0
-        mock_get.assert_called_once()
+        assert rate == 0.025
 
     def test_get_fee_rate_via_get_fee_rate_endpoint(self):
+        """Falls through to GET_FEE_RATE when token not in fee_infos or condition_map."""
         client = _make_client()
         with patch.object(client, "_get", return_value={"base_fee": 0.05}) as mock_get:
             rate = client.get_fee_rate_bps(TOKEN_ID)
         assert rate == 0.05
         mock_get.assert_called_once()
 
-    def test_get_fee_rate_preserves_existing_exponent(self):
-        """GET_FEE_RATE fallback must not overwrite an existing exponent."""
+    def test_get_fee_rate_endpoint_sets_exponent_zero(self):
+        """GET_FEE_RATE fallback sets exponent to 0 (no exponent from that endpoint)."""
         client = _make_client()
-        # Exponent already populated (e.g. from a prior market info fetch)
-        client._ClobClient__fee_infos[TOKEN_ID] = FeeInfo(rate=None, exponent=3.0)
-
         with patch.object(client, "_get", return_value={"base_fee": 0.04}):
             client.get_fee_rate_bps(TOKEN_ID)
 
         fi = client._ClobClient__fee_infos[TOKEN_ID]
         assert fi.rate == 0.04
-        assert fi.exponent == 3.0
+        assert fi.exponent == 0.0
+
+    def test_no_refetch_after_cache_hit(self):
+        """Once in fee_infos, no further _get calls for rate."""
+        client = _make_client()
+        _inject_market_info(client, TOKEN_ID, rate=0.02, exponent=2.0)
+
+        with patch.object(client, "_get") as mock_get:
+            client.get_fee_rate_bps(TOKEN_ID)
+
+        mock_get.assert_not_called()
 
 
 class TestGetFeeExponent:
@@ -113,6 +107,13 @@ class TestGetFeeExponent:
         client = _make_client()
         _inject_market_info(client, TOKEN_ID, rate=0.02, exponent=2.0)
         assert client.get_fee_exponent(TOKEN_ID) == 2.0
+
+    def test_cache_hit_any_fee_info_entry(self):
+        """Any entry in __fee_infos satisfies the cache check (returns stored exponent)."""
+        client = _make_client()
+        # Simulate GET_FEE_RATE fallback: exponent=0
+        client._ClobClient__fee_infos[TOKEN_ID] = FeeInfo(rate=0.03, exponent=0.0)
+        assert client.get_fee_exponent(TOKEN_ID) == 0.0
 
     def test_fetches_market_info_when_not_cached(self):
         client = _make_client()
@@ -123,17 +124,15 @@ class TestGetFeeExponent:
             "mts": "0.01",
             "nr": False,
             "fd": {"r": 0.02, "e": 4.0},
-            "mbf": 0,
-            "tbf": 0,
         }
         with patch.object(client, "_get", return_value=clob_market_response):
             exponent = client.get_fee_exponent(TOKEN_ID)
 
         assert exponent == 4.0
 
-    def test_exponent_only_entry_does_not_retrigger_fetch(self):
+    def test_no_refetch_after_cache_hit(self):
+        """Once in fee_infos, no further _get calls for exponent."""
         client = _make_client()
-        # Full market info fetched, exponent set
         _inject_market_info(client, TOKEN_ID, rate=0.02, exponent=1.5)
 
         with patch.object(client, "_get") as mock_get:
@@ -142,31 +141,56 @@ class TestGetFeeExponent:
         assert exponent == 1.5
         mock_get.assert_not_called()
 
-    def test_rate_only_entry_still_triggers_market_info_fetch(self):
-        """
-        If rate was stored via GET_FEE_RATE but exponent is None,
-        get_fee_exponent must fetch market info.
-        """
-        client = _make_client()
-        client._ClobClient__fee_infos[TOKEN_ID] = FeeInfo(rate=0.03, exponent=None)
-        client._ClobClient__token_condition_map[TOKEN_ID] = CONDITION_ID
 
-        clob_market_response = {
+class TestGetClobMarketInfo:
+    def test_sets_fee_info_with_defaults_when_fd_missing(self):
+        """When fd is missing from response, fee info defaults to rate=0, exponent=0."""
+        client = _make_client()
+
+        response = {
+            "t": [{"t": TOKEN_ID}],
+            "mts": "0.01",
+            "nr": False,
+        }
+        with patch.object(client, "_get", return_value=response):
+            client.get_clob_market_info(CONDITION_ID)
+
+        fi = client._ClobClient__fee_infos.get(TOKEN_ID)
+        assert fi is not None
+        assert fi.rate == 0.0
+        assert fi.exponent == 0.0
+
+    def test_sets_fee_info_from_fd(self):
+        client = _make_client()
+
+        response = {
             "t": [{"t": TOKEN_ID}],
             "mts": "0.01",
             "nr": False,
             "fd": {"r": 0.03, "e": 2.0},
-            "mbf": 0,
-            "tbf": 0,
         }
-        with patch.object(client, "_get", return_value=clob_market_response):
-            exponent = client.get_fee_exponent(TOKEN_ID)
+        with patch.object(client, "_get", return_value=response):
+            client.get_clob_market_info(CONDITION_ID)
 
-        assert exponent == 2.0
+        fi = client._ClobClient__fee_infos[TOKEN_ID]
+        assert fi.rate == 0.03
+        assert fi.exponent == 2.0
+
+    def test_no_repeated_fetch_after_clob_market_info(self):
+        """After getClobMarketInfo populates fee_infos, get_fee_rate_bps should not re-fetch."""
+        client = _make_client()
+        _inject_market_info(client, TOKEN_ID, rate=0.02, exponent=2.0)
+
+        with patch.object(client, "_get") as mock_get:
+            client.get_fee_rate_bps(TOKEN_ID)
+            client.get_fee_exponent(TOKEN_ID)
+
+        mock_get.assert_not_called()
 
 
 class TestEnsureMarketInfoCached:
-    def test_no_refetch_after_market_info_fetched(self):
+    def test_no_refetch_when_fee_infos_has_token(self):
+        """Returns immediately if token already in __fee_infos."""
         client = _make_client()
         _inject_market_info(client, TOKEN_ID, rate=0.02, exponent=2.0)
 
@@ -175,7 +199,7 @@ class TestEnsureMarketInfoCached:
 
         mock_get.assert_not_called()
 
-    def test_fetches_when_not_in_fetched_set(self):
+    def test_fetches_when_not_in_fee_infos(self):
         client = _make_client()
         client._ClobClient__token_condition_map[TOKEN_ID] = CONDITION_ID
 
@@ -184,31 +208,20 @@ class TestEnsureMarketInfoCached:
             "mts": "0.01",
             "nr": False,
             "fd": {"r": 0.01, "e": 1.0},
-            "mbf": 0,
-            "tbf": 0,
         }
         with patch.object(client, "_get", return_value=clob_market_response):
             client._ClobClient__ensure_market_info_cached(TOKEN_ID)
 
-        assert TOKEN_ID in client._ClobClient__market_info_fetched
+        assert TOKEN_ID in client._ClobClient__fee_infos
 
-    def test_rate_only_in_fee_infos_still_triggers_fetch(self):
-        """Even with a FeeInfo entry (rate only), fetch must occur if not in __market_info_fetched."""
+    def test_get_fee_rate_endpoint_entry_blocks_refetch(self):
+        """If GET_FEE_RATE stored a FeeInfo, ensureMarketInfoCached returns early."""
         client = _make_client()
-        client._ClobClient__fee_infos[TOKEN_ID] = FeeInfo(rate=0.05, exponent=None)
+        # Simulate GET_FEE_RATE fallback result
+        client._ClobClient__fee_infos[TOKEN_ID] = FeeInfo(rate=0.05, exponent=0.0)
         client._ClobClient__token_condition_map[TOKEN_ID] = CONDITION_ID
 
-        clob_market_response = {
-            "t": [{"t": TOKEN_ID}],
-            "mts": "0.01",
-            "nr": False,
-            "fd": {"r": 0.05, "e": 3.0},
-            "mbf": 0,
-            "tbf": 0,
-        }
-        with patch.object(client, "_get", return_value=clob_market_response):
+        with patch.object(client, "_get") as mock_get:
             client._ClobClient__ensure_market_info_cached(TOKEN_ID)
 
-        fi = client._ClobClient__fee_infos[TOKEN_ID]
-        assert fi.exponent == 3.0
-        assert TOKEN_ID in client._ClobClient__market_info_fetched
+        mock_get.assert_not_called()

--- a/tests/test_client_fee_cache.py
+++ b/tests/test_client_fee_cache.py
@@ -1,0 +1,214 @@
+"""
+Tests for FeeInfo cache correctness in ClobClient.
+
+Regression coverage for the bug where get_fee_rate_bps (GET_FEE_RATE fallback)
+stored a FeeInfo with only rate set, causing get_fee_exponent to see the key and
+return exponent=None (formerly 0.0) without ever fetching real market info.
+"""
+
+from unittest.mock import MagicMock, patch
+import pytest
+
+from py_clob_client_v2.client import ClobClient
+from py_clob_client_v2.clob_types import FeeInfo
+
+
+HOST = "https://clob.example.com"
+CHAIN_ID = 137
+TOKEN_ID = "0xabc123"
+CONDITION_ID = "0xdeadbeef"
+
+
+def _make_client() -> ClobClient:
+    return ClobClient(host=HOST, chain_id=CHAIN_ID)
+
+
+def _inject_market_info(client: ClobClient, token_id: str, rate: float, exponent: float):
+    """Simulate get_clob_market_info populating all cache fields."""
+    fi = FeeInfo(rate=rate, exponent=exponent)
+    client._ClobClient__fee_infos[token_id] = fi
+    client._ClobClient__market_info_fetched.add(token_id)
+    client._ClobClient__tick_sizes[token_id] = "0.01"
+    client._ClobClient__neg_risk[token_id] = False
+    client._ClobClient__token_condition_map[token_id] = CONDITION_ID
+
+
+class TestFeeInfoSentinels:
+    def test_fee_info_defaults_are_none(self):
+        fi = FeeInfo()
+        assert fi.rate is None
+        assert fi.exponent is None
+
+    def test_fee_info_explicit_values(self):
+        fi = FeeInfo(rate=0.02, exponent=2.0)
+        assert fi.rate == 0.02
+        assert fi.exponent == 2.0
+
+
+class TestGetFeeRateBps:
+    def test_returns_cached_rate_from_market_info(self):
+        client = _make_client()
+        _inject_market_info(client, TOKEN_ID, rate=0.02, exponent=2.0)
+        assert client.get_fee_rate_bps(TOKEN_ID) == 0.02
+
+    def test_rate_only_entry_does_not_satisfy_cache_check(self):
+        """A FeeInfo with only rate set must NOT prevent fetching exponent later."""
+        client = _make_client()
+        # Simulate the GET_FEE_RATE fallback: rate stored, exponent still None
+        client._ClobClient__fee_infos[TOKEN_ID] = FeeInfo(rate=0.03, exponent=None)
+
+        # get_fee_rate_bps should still return the cached rate
+        assert client.get_fee_rate_bps(TOKEN_ID) == 0.03
+
+    def test_get_fee_rate_fallback_does_not_block_exponent_fetch(self):
+        """
+        Core regression: after get_fee_rate_bps uses GET_FEE_RATE fallback,
+        get_fee_exponent must still trigger __ensure_market_info_cached.
+        """
+        client = _make_client()
+
+        # Simulate GET_FEE_RATE fallback storing rate-only FeeInfo
+        client._ClobClient__fee_infos[TOKEN_ID] = FeeInfo(rate=0.03, exponent=None)
+        # token is NOT in __market_info_fetched
+
+        clob_market_response = {
+            "t": [{"t": TOKEN_ID}],
+            "mts": "0.01",
+            "nr": False,
+            "fd": {"r": 0.03, "e": 2.0},
+            "mbf": 0,
+            "tbf": 0,
+        }
+
+        with patch.object(client, "_get", return_value=clob_market_response) as mock_get, \
+             patch.object(client, "_ClobClient__token_condition_map", {TOKEN_ID: CONDITION_ID}):
+            exponent = client.get_fee_exponent(TOKEN_ID)
+
+        assert exponent == 2.0
+        mock_get.assert_called_once()
+
+    def test_get_fee_rate_via_get_fee_rate_endpoint(self):
+        client = _make_client()
+        with patch.object(client, "_get", return_value={"base_fee": 0.05}) as mock_get:
+            rate = client.get_fee_rate_bps(TOKEN_ID)
+        assert rate == 0.05
+        mock_get.assert_called_once()
+
+    def test_get_fee_rate_preserves_existing_exponent(self):
+        """GET_FEE_RATE fallback must not overwrite an existing exponent."""
+        client = _make_client()
+        # Exponent already populated (e.g. from a prior market info fetch)
+        client._ClobClient__fee_infos[TOKEN_ID] = FeeInfo(rate=None, exponent=3.0)
+
+        with patch.object(client, "_get", return_value={"base_fee": 0.04}):
+            client.get_fee_rate_bps(TOKEN_ID)
+
+        fi = client._ClobClient__fee_infos[TOKEN_ID]
+        assert fi.rate == 0.04
+        assert fi.exponent == 3.0
+
+
+class TestGetFeeExponent:
+    def test_returns_cached_exponent_from_market_info(self):
+        client = _make_client()
+        _inject_market_info(client, TOKEN_ID, rate=0.02, exponent=2.0)
+        assert client.get_fee_exponent(TOKEN_ID) == 2.0
+
+    def test_fetches_market_info_when_not_cached(self):
+        client = _make_client()
+        client._ClobClient__token_condition_map[TOKEN_ID] = CONDITION_ID
+
+        clob_market_response = {
+            "t": [{"t": TOKEN_ID}],
+            "mts": "0.01",
+            "nr": False,
+            "fd": {"r": 0.02, "e": 4.0},
+            "mbf": 0,
+            "tbf": 0,
+        }
+        with patch.object(client, "_get", return_value=clob_market_response):
+            exponent = client.get_fee_exponent(TOKEN_ID)
+
+        assert exponent == 4.0
+
+    def test_exponent_only_entry_does_not_retrigger_fetch(self):
+        client = _make_client()
+        # Full market info fetched, exponent set
+        _inject_market_info(client, TOKEN_ID, rate=0.02, exponent=1.5)
+
+        with patch.object(client, "_get") as mock_get:
+            exponent = client.get_fee_exponent(TOKEN_ID)
+
+        assert exponent == 1.5
+        mock_get.assert_not_called()
+
+    def test_rate_only_entry_still_triggers_market_info_fetch(self):
+        """
+        If rate was stored via GET_FEE_RATE but exponent is None,
+        get_fee_exponent must fetch market info.
+        """
+        client = _make_client()
+        client._ClobClient__fee_infos[TOKEN_ID] = FeeInfo(rate=0.03, exponent=None)
+        client._ClobClient__token_condition_map[TOKEN_ID] = CONDITION_ID
+
+        clob_market_response = {
+            "t": [{"t": TOKEN_ID}],
+            "mts": "0.01",
+            "nr": False,
+            "fd": {"r": 0.03, "e": 2.0},
+            "mbf": 0,
+            "tbf": 0,
+        }
+        with patch.object(client, "_get", return_value=clob_market_response):
+            exponent = client.get_fee_exponent(TOKEN_ID)
+
+        assert exponent == 2.0
+
+
+class TestEnsureMarketInfoCached:
+    def test_no_refetch_after_market_info_fetched(self):
+        client = _make_client()
+        _inject_market_info(client, TOKEN_ID, rate=0.02, exponent=2.0)
+
+        with patch.object(client, "_get") as mock_get:
+            client._ClobClient__ensure_market_info_cached(TOKEN_ID)
+
+        mock_get.assert_not_called()
+
+    def test_fetches_when_not_in_fetched_set(self):
+        client = _make_client()
+        client._ClobClient__token_condition_map[TOKEN_ID] = CONDITION_ID
+
+        clob_market_response = {
+            "t": [{"t": TOKEN_ID}],
+            "mts": "0.01",
+            "nr": False,
+            "fd": {"r": 0.01, "e": 1.0},
+            "mbf": 0,
+            "tbf": 0,
+        }
+        with patch.object(client, "_get", return_value=clob_market_response):
+            client._ClobClient__ensure_market_info_cached(TOKEN_ID)
+
+        assert TOKEN_ID in client._ClobClient__market_info_fetched
+
+    def test_rate_only_in_fee_infos_still_triggers_fetch(self):
+        """Even with a FeeInfo entry (rate only), fetch must occur if not in __market_info_fetched."""
+        client = _make_client()
+        client._ClobClient__fee_infos[TOKEN_ID] = FeeInfo(rate=0.05, exponent=None)
+        client._ClobClient__token_condition_map[TOKEN_ID] = CONDITION_ID
+
+        clob_market_response = {
+            "t": [{"t": TOKEN_ID}],
+            "mts": "0.01",
+            "nr": False,
+            "fd": {"r": 0.05, "e": 3.0},
+            "mbf": 0,
+            "tbf": 0,
+        }
+        with patch.object(client, "_get", return_value=clob_market_response):
+            client._ClobClient__ensure_market_info_cached(TOKEN_ID)
+
+        fi = client._ClobClient__fee_infos[TOKEN_ID]
+        assert fi.exponent == 3.0
+        assert TOKEN_ID in client._ClobClient__market_info_fetched

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -279,6 +279,26 @@ class TestUtilities(TestCase):
         builder_fee = effective * builder_taker_fee_rate
         self.assertAlmostEqual(effective + platform_fee + builder_fee, budget, delta=1e-10)
 
+    def test_adjust_market_buy_amount_price_near_boundary(self):
+        # price near minimum tick (0.0001) — pfr/price quotient is large, float errors compound
+        budget = 50.0
+        price = 0.0001
+        fee_rate = 0.25
+        fee_exponent = 2.0
+        builder_taker_fee_rate = 0.01
+        effective = adjust_market_buy_amount(
+            amount=100.0,
+            user_usdc_balance=budget,
+            price=price,
+            fee_rate=fee_rate,
+            fee_exponent=fee_exponent,
+            builder_taker_fee_rate=builder_taker_fee_rate,
+        )
+        platform_fee_rate = fee_rate * (price * (1 - price)) ** fee_exponent
+        platform_fee = (effective / price) * platform_fee_rate
+        builder_fee = effective * builder_taker_fee_rate
+        self.assertAlmostEqual(effective + platform_fee + builder_fee, budget, delta=1e-10)
+
     def test_adjust_market_buy_amount_exactly_at_limit(self):
         # balance == total_cost triggers the adjustment path
         price = 0.5

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -8,6 +8,7 @@ from py_clob_client_v2.order_utils.model import SignedOrderV2, Side, SignatureTy
 from py_clob_client_v2.signer import Signer
 from py_clob_client_v2.order_utils.model.order_data_v2 import order_to_json_v2
 from py_clob_client_v2.utilities import (
+    adjust_market_buy_amount,
     generate_orderbook_summary_hash,
     is_tick_size_smaller,
     parse_raw_orderbook_summary,
@@ -213,6 +214,89 @@ class TestUtilities(TestCase):
         self.assertTrue(is_tick_size_smaller("0.0001", "0.001"))
         self.assertFalse(is_tick_size_smaller("0.1", "0.01"))
         self.assertFalse(is_tick_size_smaller("0.1", "0.1"))
+
+    def test_adjust_market_buy_amount_sufficient_balance(self):
+        # balance > total_cost: original amount returned unchanged
+        result = adjust_market_buy_amount(
+            amount=10.0,
+            user_usdc_balance=100.0,
+            price=0.5,
+            fee_rate=0.25,
+            fee_exponent=2.0,
+        )
+        self.assertEqual(result, 10.0)
+
+    def test_adjust_market_buy_amount_platform_fee_only(self):
+        # invariant: effective + platform_fee == budget (within 1e-10)
+        budget = 50.0
+        price = 0.5
+        fee_rate = 0.25
+        fee_exponent = 2.0
+        effective = adjust_market_buy_amount(
+            amount=100.0,
+            user_usdc_balance=budget,
+            price=price,
+            fee_rate=fee_rate,
+            fee_exponent=fee_exponent,
+        )
+        platform_fee_rate = fee_rate * (price * (1 - price)) ** fee_exponent
+        platform_fee = (effective / price) * platform_fee_rate
+        self.assertAlmostEqual(effective + platform_fee, budget, delta=1e-10)
+
+    def test_adjust_market_buy_amount_builder_fee_only(self):
+        # invariant: effective + builder_fee == budget (within 1e-10)
+        budget = 50.0
+        price = 0.5
+        builder_taker_fee_rate = 0.01
+        effective = adjust_market_buy_amount(
+            amount=100.0,
+            user_usdc_balance=budget,
+            price=price,
+            fee_rate=0,
+            fee_exponent=0,
+            builder_taker_fee_rate=builder_taker_fee_rate,
+        )
+        builder_fee = effective * builder_taker_fee_rate
+        self.assertAlmostEqual(effective + builder_fee, budget, delta=1e-10)
+
+    def test_adjust_market_buy_amount_combined_fees(self):
+        # invariant: effective + platform_fee + builder_fee == budget (within 1e-10)
+        budget = 50.0
+        price = 0.5
+        fee_rate = 0.25
+        fee_exponent = 2.0
+        builder_taker_fee_rate = 0.01
+        effective = adjust_market_buy_amount(
+            amount=100.0,
+            user_usdc_balance=budget,
+            price=price,
+            fee_rate=fee_rate,
+            fee_exponent=fee_exponent,
+            builder_taker_fee_rate=builder_taker_fee_rate,
+        )
+        platform_fee_rate = fee_rate * (price * (1 - price)) ** fee_exponent
+        platform_fee = (effective / price) * platform_fee_rate
+        builder_fee = effective * builder_taker_fee_rate
+        self.assertAlmostEqual(effective + platform_fee + builder_fee, budget, delta=1e-10)
+
+    def test_adjust_market_buy_amount_exactly_at_limit(self):
+        # balance == total_cost triggers the adjustment path
+        price = 0.5
+        fee_rate = 0.25
+        fee_exponent = 2.0
+        platform_fee_rate = fee_rate * (price * (1 - price)) ** fee_exponent
+        amount = 48.484848484848484
+        platform_fee = (amount / price) * platform_fee_rate
+        budget = amount + platform_fee  # exactly at limit
+        effective = adjust_market_buy_amount(
+            amount=amount,
+            user_usdc_balance=budget,
+            price=price,
+            fee_rate=fee_rate,
+            fee_exponent=fee_exponent,
+        )
+        recalc_fee = (effective / price) * platform_fee_rate
+        self.assertAlmostEqual(effective + recalc_fee, budget, delta=1e-10)
 
     def test_price_valid(self):
         self.assertTrue(price_valid(0.5, "0.1"))


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes fee/amount calculations for market BUY orders, including new Decimal-based math and a new builder-fee-rate lookup, which could affect order sizing and execution in edge cases.
> 
> **Overview**
> **Refactors fee handling to use a single `FeeInfo` cache** in `ClobClient`, replacing separate fee rate/exponent caches and making `get_fee_rate_bps`/`get_fee_exponent` return floats with consistent cache semantics (including `GET_FEE_RATE` fallback setting exponent to `0`).
> 
> **Adds builder fee-rate fetching/caching** via a new `GET_BUILDER_FEE_RATE` endpoint and applies the cached builder taker fee when adjusting market BUY order amounts.
> 
> **Improves numerical stability** of `adjust_market_buy_amount` by switching the fee/budget calculation to `Decimal`, and adds targeted tests covering cache behavior and fee-adjustment invariants.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9edeead86becffe4c59246e34bd93b6fdbe0b063. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->