### PR TITLE
fix: nr property check

### DIFF
--- a/py_clob_client_v2/client.py
+++ b/py_clob_client_v2/client.py
@@ -282,7 +282,7 @@ class ClobClient:
             token_id = token["t"]
             self.__token_condition_map[token_id] = condition_id
             self.__tick_sizes[token_id] = str(result["mts"])
-            self.__neg_risk[token_id] = result["nr"]
+            self.__neg_risk[token_id] = result.get("nr", False)
 
             fd = result.get("fd") or {}
             self.__fee_infos[token_id] = FeeInfo(


### PR DESCRIPTION
for neg_risk=false markets, the `nr` property is not set and we get a KeyError

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small defensive change that prevents a `KeyError` when the market info response omits the `nr` field, defaulting cached `neg_risk` to `False`.
> 
> **Overview**
> Fixes `get_clob_market_info` to treat the `nr` (neg risk) flag as optional by using `result.get("nr", False)` when populating the per-token `__neg_risk` cache.
> 
> This prevents `KeyError` crashes for markets where `neg_risk=false` and the API omits the `nr` property.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9db889f7608d7de27b5a0236be89f7b910e7d758. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->