### PR TITLE
chore: update address

### DIFF
--- a/py_clob_client_v2/config.py
+++ b/py_clob_client_v2/config.py
@@ -16,7 +16,7 @@ def get_contract_config(chain_id: int) -> ContractConfig:
             collateral="0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB",
             conditional_tokens="0x4D97DCd97eC945f40cF65F87097ACe5EA0476045",
             exchange_v2="0xE111180000d2663C0091e4f400237545B87B996B",
-            neg_risk_exchange_v2="0xe2222d002000Ba0053CEF3375333610F64600036",
+            neg_risk_exchange_v2="0xe2222d279d744050d28e00520010520000310F59",
         ),
         80002: ContractConfig(
             exchange="0xdFE02Eb6733538f8Ea35D585af8DE5958AD99E40",
@@ -25,7 +25,7 @@ def get_contract_config(chain_id: int) -> ContractConfig:
             collateral="0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB",
             conditional_tokens="0x69308FB512518e39F9b16112fA8d994F4e2Bf8bB",
             exchange_v2="0xE111180000d2663C0091e4f400237545B87B996B",
-            neg_risk_exchange_v2="0xe2222d002000Ba0053CEF3375333610F64600036",
+            neg_risk_exchange_v2="0xe2222d279d744050d28e00520010520000310F59",
         ),
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this only changes a configuration constant, but an incorrect contract address would cause V2 neg-risk order building to target the wrong on-chain contract.
> 
> **Overview**
> Updates the `neg_risk_exchange_v2` contract address returned by `get_contract_config` for chain IDs `137` and `80002`, so V2 *neg-risk* order building routes to the new exchange contract.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ceca161190f212bf2ae8eb5e81fd6649d54936fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->