### PR TITLE
chore: readme and license

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Polymarket
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,80 @@
-# py-clob-client-v2
+# PY Polymarket CLOB Client V2
+
+Python client for the Polymarket CLOB (v2)
+
+### Usage
+
+```python
+# pip install py_clob_client_v2
+
+import os
+from py_clob_client_v2 import ApiCreds, ClobClient, OrderArgs, OrderType, PartialCreateOrderOptions, Side
+
+host = "https://clob-v2.polymarket.com"
+chain_id = 137  # or 80002 for Amoy testnet
+
+# Step 1: obtain API credentials using your wallet (L1 auth)
+client = ClobClient(host=host, chain_id=chain_id, key=os.environ["PK"])
+creds = client.create_or_derive_api_key()
+
+# Step 2: initialize a fully-authenticated client (L1 + L2)
+client = ClobClient(host=host, chain_id=chain_id, key=os.environ["PK"], creds=creds)
+
+# Place a resting limit buy (GTC)
+resp = client.create_and_post_order(
+    order_args=OrderArgs(
+        token_id="",  # token ID of the market outcome — get from https://docs.polymarket.com
+        price=0.4,
+        side=Side.BUY,
+        size=100,
+    ),
+    options=PartialCreateOrderOptions(tick_size="0.01"),
+    order_type=OrderType.GTC,
+)
+print(resp)
+```
+
+See [examples](examples/) for more information.
+
+### Market Orders
+
+```python
+from py_clob_client_v2 import MarketOrderArgs
+
+# Market buy — amount is in USDC
+# OrderType.FOK: entire order must fill immediately or it is cancelled
+# OrderType.FAK: fills as much as possible, remainder is cancelled
+resp = client.create_and_post_market_order(
+    order_args=MarketOrderArgs(
+        token_id="",
+        amount=100,  # USDC
+        side=Side.BUY,
+        order_type=OrderType.FOK,
+    ),
+    options=PartialCreateOrderOptions(tick_size="0.01"),
+    order_type=OrderType.FOK,
+)
+print(resp)
+```
+
+### Authentication
+
+The client has two authentication levels:
+
+**L1** — wallet signature (EIP-712). Required to create or derive API keys.
+
+```python
+client = ClobClient(host=host, chain_id=chain_id, key=os.environ["PK"])
+creds = client.create_or_derive_api_key()
+```
+
+**L2** — HMAC with API credentials. Required for order placement, cancellation, and account data.
+
+```python
+creds = ApiCreds(
+    api_key=os.environ["CLOB_API_KEY"],
+    api_secret=os.environ["CLOB_SECRET"],
+    api_passphrase=os.environ["CLOB_PASS_PHRASE"],
+)
+client = ClobClient(host=host, chain_id=chain_id, key=os.environ["PK"], creds=creds)
+```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Python client for the Polymarket CLOB (v2)
 import os
 from py_clob_client_v2 import ApiCreds, ClobClient, OrderArgs, OrderType, PartialCreateOrderOptions, Side
 
-host = "https://clob-v2.polymarket.com"
+host = "<polymarket-clob-host>"
 chain_id = 137  # or 80002 for Amoy testnet
 
 # Step 1: obtain API credentials using your wallet (L1 auth)

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,6 @@ setuptools.setup(
         "eth-utils>=4.1.1",
         "poly_eip712_structs>=0.0.1",
         "py-order-utils>=0.3.2",
-        "python-dotenv",
-        "py-builder-signing-sdk>=0.0.2",
         "httpx[http2]>=0.27.0",
     ],
     project_urls={
@@ -32,6 +30,6 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=["tests*"]),
     python_requires=">=3.9.10",
 )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation/licensing plus minor packaging and CI adjustments; main impact is build/release behavior if excluded deps or checkout action version mismatches expectations.
> 
> **Overview**
> Adds an MIT `LICENSE` and replaces the minimal `README.md` with usage/authentication examples (including limit and market order snippets).
> 
> Updates packaging/release plumbing: the release workflow downgrades `actions/checkout` to `v4`, and `setup.py` drops `python-dotenv`/`py-builder-signing-sdk` from `install_requires` while excluding `tests*` from the distributed packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 936440384378cc581b7a445f5efc52c854b2720c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->