### PR TITLE
ft: orders postOnly

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,8 +14,6 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
-        with:
-          persist-credentials: false
 
       - uses: actions/setup-python@v5
         with:

--- a/py_clob_client_v2/client.py
+++ b/py_clob_client_v2/client.py
@@ -782,12 +782,11 @@ class ClobClient:
         order_args: MarketOrderArgsV2,
         options: PartialCreateOrderOptions = None,
         order_type: OrderType = OrderType.FOK,
-        post_only: bool = False,
         defer_exec: bool = False,
     ):
         return self._retry_on_version_update(
             lambda: self.post_order(
-                self.create_market_order(order_args, options), order_type, post_only, defer_exec
+                self.create_market_order(order_args, options), order_type, False, defer_exec
             )
         )
 
@@ -799,6 +798,8 @@ class ClobClient:
         defer_exec: bool = False,
     ):
         self.assert_level_2_auth()
+        if post_only and order_type in (OrderType.FOK, OrderType.FAK):
+            raise ValueError("post_only is not supported for FOK/FAK orders")
 
         owner = self.creds.api_key or ""
         order_payload = (

--- a/py_clob_client_v2/client.py
+++ b/py_clob_client_v2/client.py
@@ -769,10 +769,11 @@ class ClobClient:
         options: PartialCreateOrderOptions = None,
         order_type: OrderType = OrderType.GTC,
         defer_exec: bool = False,
+        post_only: bool = False,
     ):
         return self._retry_on_version_update(
             lambda: self.post_order(
-                self.create_order(order_args, options), order_type, defer_exec
+                self.create_order(order_args, options), order_type, defer_exec, post_only
             )
         )
 
@@ -782,10 +783,11 @@ class ClobClient:
         options: PartialCreateOrderOptions = None,
         order_type: OrderType = OrderType.FOK,
         defer_exec: bool = False,
+        post_only: bool = False,
     ):
         return self._retry_on_version_update(
             lambda: self.post_order(
-                self.create_market_order(order_args, options), order_type, defer_exec
+                self.create_market_order(order_args, options), order_type, defer_exec, post_only
             )
         )
 
@@ -794,14 +796,15 @@ class ClobClient:
         order,
         order_type: OrderType = OrderType.GTC,
         defer_exec: bool = False,
+        post_only: bool = False,
     ):
         self.assert_level_2_auth()
 
         owner = self.creds.api_key or ""
         order_payload = (
-            order_to_json_v2(order, owner, order_type, defer_exec)
+            order_to_json_v2(order, owner, order_type, defer_exec, post_only)
             if _is_v2_order(order)
-            else order_to_json_v1(order, owner, order_type, defer_exec)
+            else order_to_json_v1(order, owner, order_type, defer_exec, post_only)
         )
         serialized = json.dumps(order_payload, separators=(",", ":"))
         headers = self._l2_headers(
@@ -815,7 +818,7 @@ class ClobClient:
 
         return res
 
-    def post_orders(self, args: list, defer_exec: bool = False):
+    def post_orders(self, args: list, defer_exec: bool = False, post_only: bool = False):
         self.assert_level_2_auth()
 
         owner = self.creds.api_key or ""
@@ -824,9 +827,9 @@ class ClobClient:
             order = arg.order
             order_type = arg.orderType
             payload = (
-                order_to_json_v2(order, owner, order_type, defer_exec)
+                order_to_json_v2(order, owner, order_type, defer_exec, post_only)
                 if _is_v2_order(order)
-                else order_to_json_v1(order, owner, order_type, defer_exec)
+                else order_to_json_v1(order, owner, order_type, defer_exec, post_only)
             )
             orders_payload.append(payload)
 

--- a/py_clob_client_v2/client.py
+++ b/py_clob_client_v2/client.py
@@ -821,6 +821,8 @@ class ClobClient:
 
     def post_orders(self, args: list, post_only: bool = False, defer_exec: bool = False):
         self.assert_level_2_auth()
+        if post_only and any(arg.orderType in (OrderType.FOK, OrderType.FAK) for arg in args):
+            raise ValueError("post_only is not supported for FOK/FAK orders")
 
         owner = self.creds.api_key or ""
         orders_payload = []

--- a/py_clob_client_v2/client.py
+++ b/py_clob_client_v2/client.py
@@ -768,12 +768,12 @@ class ClobClient:
         order_args: OrderArgsV2,
         options: PartialCreateOrderOptions = None,
         order_type: OrderType = OrderType.GTC,
-        defer_exec: bool = False,
         post_only: bool = False,
+        defer_exec: bool = False,
     ):
         return self._retry_on_version_update(
             lambda: self.post_order(
-                self.create_order(order_args, options), order_type, defer_exec, post_only
+                self.create_order(order_args, options), order_type, post_only, defer_exec
             )
         )
 
@@ -782,12 +782,12 @@ class ClobClient:
         order_args: MarketOrderArgsV2,
         options: PartialCreateOrderOptions = None,
         order_type: OrderType = OrderType.FOK,
-        defer_exec: bool = False,
         post_only: bool = False,
+        defer_exec: bool = False,
     ):
         return self._retry_on_version_update(
             lambda: self.post_order(
-                self.create_market_order(order_args, options), order_type, defer_exec, post_only
+                self.create_market_order(order_args, options), order_type, post_only, defer_exec
             )
         )
 
@@ -795,16 +795,16 @@ class ClobClient:
         self,
         order,
         order_type: OrderType = OrderType.GTC,
-        defer_exec: bool = False,
         post_only: bool = False,
+        defer_exec: bool = False,
     ):
         self.assert_level_2_auth()
 
         owner = self.creds.api_key or ""
         order_payload = (
-            order_to_json_v2(order, owner, order_type, defer_exec, post_only)
+            order_to_json_v2(order, owner, order_type, post_only, defer_exec)
             if _is_v2_order(order)
-            else order_to_json_v1(order, owner, order_type, defer_exec, post_only)
+            else order_to_json_v1(order, owner, order_type, post_only, defer_exec)
         )
         serialized = json.dumps(order_payload, separators=(",", ":"))
         headers = self._l2_headers(
@@ -818,7 +818,7 @@ class ClobClient:
 
         return res
 
-    def post_orders(self, args: list, defer_exec: bool = False, post_only: bool = False):
+    def post_orders(self, args: list, post_only: bool = False, defer_exec: bool = False):
         self.assert_level_2_auth()
 
         owner = self.creds.api_key or ""
@@ -827,9 +827,9 @@ class ClobClient:
             order = arg.order
             order_type = arg.orderType
             payload = (
-                order_to_json_v2(order, owner, order_type, defer_exec, post_only)
+                order_to_json_v2(order, owner, order_type, post_only, defer_exec)
                 if _is_v2_order(order)
-                else order_to_json_v1(order, owner, order_type, defer_exec, post_only)
+                else order_to_json_v1(order, owner, order_type, post_only, defer_exec)
             )
             orders_payload.append(payload)
 

--- a/py_clob_client_v2/order_utils/model/order_data_v1.py
+++ b/py_clob_client_v2/order_utils/model/order_data_v1.py
@@ -52,6 +52,7 @@ def order_to_json_v1(
     owner: str,
     order_type: str,
     defer_exec: bool = False,
+    post_only: bool = False,
 ) -> dict:
     side = SideString.BUY if order.side == Side.BUY else SideString.SELL
     return {
@@ -73,4 +74,5 @@ def order_to_json_v1(
         "owner": owner,
         "orderType": order_type,
         "deferExec": defer_exec,
+        "postOnly": post_only,
     }

--- a/py_clob_client_v2/order_utils/model/order_data_v1.py
+++ b/py_clob_client_v2/order_utils/model/order_data_v1.py
@@ -51,8 +51,8 @@ def order_to_json_v1(
     order: "SignedOrderV1",
     owner: str,
     order_type: str,
-    defer_exec: bool = False,
     post_only: bool = False,
+    defer_exec: bool = False,
 ) -> dict:
     side = SideString.BUY if order.side == Side.BUY else SideString.SELL
     return {

--- a/py_clob_client_v2/order_utils/model/order_data_v2.py
+++ b/py_clob_client_v2/order_utils/model/order_data_v2.py
@@ -52,6 +52,7 @@ def order_to_json_v2(
     owner: str,
     order_type: str,
     defer_exec: bool = False,
+    post_only: bool = False,
 ) -> dict:
     side = SideString.BUY if order.side == Side.BUY else SideString.SELL
     return {
@@ -73,4 +74,5 @@ def order_to_json_v2(
         "owner": owner,
         "orderType": order_type,
         "deferExec": defer_exec,
+        "postOnly": post_only,
     }

--- a/py_clob_client_v2/order_utils/model/order_data_v2.py
+++ b/py_clob_client_v2/order_utils/model/order_data_v2.py
@@ -51,8 +51,8 @@ def order_to_json_v2(
     order: "SignedOrderV2",
     owner: str,
     order_type: str,
-    defer_exec: bool = False,
     post_only: bool = False,
+    defer_exec: bool = False,
 ) -> dict:
     side = SideString.BUY if order.side == Side.BUY else SideString.SELL
     return {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new `post_only` parameter and serializes it into order submission payloads, which changes client method signatures and could break positional-call sites or alter execution behavior if misused. Also enforces new validation rejecting `post_only` with `FOK`/`FAK` orders.
> 
> **Overview**
> Adds a `post_only` option to `create_and_post_order`, `post_order`, and `post_orders`, and includes `postOnly` in both V1 and V2 order JSON payloads.
> 
> Introduces client-side validation to reject `post_only` for `FOK`/`FAK` order types, and adjusts market-order posting to always send `post_only=False`.
> 
> Updates the release workflow to stop setting `persist-credentials: false` on checkout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a5bc595d53e8c0461ebf92769949ae0247bce5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->