### PR TITLE
ft: add getHeartbeat()

### DIFF
--- a/py_clob_client_v2/client.py
+++ b/py_clob_client_v2/client.py
@@ -90,6 +90,7 @@ from .endpoints import (
     IS_ORDER_SCORING,
     ORDERS,
     PRE_MIGRATION_ORDERS,
+    POST_HEARTBEAT,
     POST_ORDER,
     POST_ORDERS,
     TIME,
@@ -234,6 +235,14 @@ class ClobClient:
 
     def get_ok(self):
         return self._get(f"{self.host}{OK}")
+
+    def post_heartbeat(self, heartbeat_id: str = "") -> dict:
+        body = {"heartbeat_id": heartbeat_id}
+        serialized = json.dumps(body, separators=(",", ":"))
+        headers = self._l2_headers(
+            "POST", POST_HEARTBEAT, body=body, serialized_body=serialized
+        )
+        return self._post(f"{self.host}{POST_HEARTBEAT}", headers=headers, data=serialized)
 
     def get_version(self) -> int:
         try:

--- a/py_clob_client_v2/client.py
+++ b/py_clob_client_v2/client.py
@@ -51,11 +51,15 @@ from .endpoints import (
     CLOSED_ONLY,
     CREATE_API_KEY,
     CREATE_BUILDER_API_KEY,
+    CREATE_READONLY_API_KEY,
     DELETE_API_KEY,
+    DELETE_READONLY_API_KEY,
     DERIVE_API_KEY,
     GET_API_KEYS,
     GET_BALANCE_ALLOWANCE,
     GET_BUILDER_API_KEYS,
+    GET_MARKET_TRADES_EVENTS,
+    GET_READONLY_API_KEYS,
     GET_BUILDER_FEE_RATE,
     GET_BUILDER_TRADES,
     GET_CLOB_MARKET,
@@ -93,6 +97,7 @@ from .endpoints import (
     POST_HEARTBEAT,
     POST_ORDER,
     POST_ORDERS,
+    REVOKE_BUILDER_API_KEY,
     TIME,
     TRADES,
     UPDATE_BALANCE_ALLOWANCE,
@@ -980,6 +985,31 @@ class ClobClient:
         self.assert_level_2_auth()
         headers = self._l2_headers("GET", GET_BUILDER_API_KEYS)
         return self._get(f"{self.host}{GET_BUILDER_API_KEYS}", headers=headers)
+
+    def revoke_builder_api_key(self):
+        self.assert_level_2_auth()
+        headers = self._l2_headers("DELETE", REVOKE_BUILDER_API_KEY)
+        return self._delete(f"{self.host}{REVOKE_BUILDER_API_KEY}", headers=headers)
+
+    def create_readonly_api_key(self):
+        self.assert_level_2_auth()
+        headers = self._l2_headers("POST", CREATE_READONLY_API_KEY)
+        return self._post(f"{self.host}{CREATE_READONLY_API_KEY}", headers=headers)
+
+    def get_readonly_api_keys(self):
+        self.assert_level_2_auth()
+        headers = self._l2_headers("GET", GET_READONLY_API_KEYS)
+        return self._get(f"{self.host}{GET_READONLY_API_KEYS}", headers=headers)
+
+    def delete_readonly_api_key(self, key: str):
+        self.assert_level_2_auth()
+        body = {"key": key}
+        serialized = json.dumps(body, separators=(",", ":"))
+        headers = self._l2_headers("DELETE", DELETE_READONLY_API_KEY, body=body, serialized_body=serialized)
+        return self._delete(f"{self.host}{DELETE_READONLY_API_KEY}", headers=headers, data=serialized)
+
+    def get_market_trades_events(self, condition_id: str):
+        return self._get(f"{self.host}{GET_MARKET_TRADES_EVENTS}{condition_id}")
 
     def __resolve_tick_size(self, token_id: str, tick_size: TickSize = None) -> TickSize:
         min_tick_size = self.get_tick_size(token_id)

--- a/py_clob_client_v2/endpoints.py
+++ b/py_clob_client_v2/endpoints.py
@@ -10,9 +10,18 @@ DELETE_API_KEY = "/auth/api-key"
 DERIVE_API_KEY = "/auth/derive-api-key"
 CLOSED_ONLY = "/auth/ban-status/closed-only"
 
+# Readonly API Key endpoints
+CREATE_READONLY_API_KEY = "/auth/readonly-api-key"
+GET_READONLY_API_KEYS = "/auth/readonly-api-keys"
+DELETE_READONLY_API_KEY = "/auth/readonly-api-key"
+
 # Builder API Key endpoints
 CREATE_BUILDER_API_KEY = "/auth/builder-api-key"
 GET_BUILDER_API_KEYS = "/auth/builder-api-key"
+REVOKE_BUILDER_API_KEY = "/auth/builder-api-key"
+
+# Live activity
+GET_MARKET_TRADES_EVENTS = "/markets/live-activity/"
 
 # Markets
 GET_SAMPLING_SIMPLIFIED_MARKETS = "/sampling-simplified-markets"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new authenticated POST/DELETE flows and key-management operations, so mistakes could cause signing/header or endpoint usage issues despite being additive client-side changes.
> 
> **Overview**
> Adds a new level-2 authenticated `post_heartbeat()` call (POST `/v1/heartbeats`) to let clients send builder heartbeats.
> 
> Extends API key management with readonly-key support (`create_readonly_api_key`, `get_readonly_api_keys`, `delete_readonly_api_key`) and adds `revoke_builder_api_key()` for builder keys.
> 
> Introduces a `get_market_trades_events(condition_id)` helper wired to the new `/markets/live-activity/` endpoint and updates `endpoints.py` with the new route constants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fab502d5b2d574f394d54064cd15613747d00f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->