### PR TITLE
Fix/v1 fee bps

### DIFF
--- a/py_clob_client_v2/client.py
+++ b/py_clob_client_v2/client.py
@@ -244,7 +244,7 @@ class ClobClient:
 
     def post_heartbeat(self, heartbeat_id: str = "") -> dict:
         body = {"heartbeat_id": heartbeat_id}
-        serialized = json.dumps(body, separators=(",", ":"))
+        serialized = json.dumps(body, separators=(",", ":"), ensure_ascii=False)
         headers = self._l2_headers(
             "POST", POST_HEARTBEAT, body=body, serialized_body=serialized
         )
@@ -823,7 +823,7 @@ class ClobClient:
             if _is_v2_order(order)
             else order_to_json_v1(order, owner, order_type, post_only, defer_exec)
         )
-        serialized = json.dumps(order_payload, separators=(",", ":"))
+        serialized = json.dumps(order_payload, separators=(",", ":"), ensure_ascii=False)
         headers = self._l2_headers(
             "POST", POST_ORDER, body=order_payload, serialized_body=serialized
         )
@@ -852,7 +852,7 @@ class ClobClient:
             )
             orders_payload.append(payload)
 
-        serialized = json.dumps(orders_payload, separators=(",", ":"))
+        serialized = json.dumps(orders_payload, separators=(",", ":"), ensure_ascii=False)
         headers = self._l2_headers(
             "POST", POST_ORDERS, body=orders_payload, serialized_body=serialized
         )
@@ -867,13 +867,13 @@ class ClobClient:
     def cancel_order(self, payload: OrderPayload):
         self.assert_level_2_auth()
         body = {"orderID": payload.orderID}
-        serialized = json.dumps(body, separators=(",", ":"))
+        serialized = json.dumps(body, separators=(",", ":"), ensure_ascii=False)
         headers = self._l2_headers("DELETE", CANCEL, body=body, serialized_body=serialized)
         return self._delete(f"{self.host}{CANCEL}", headers=headers, data=serialized)
 
     def cancel_orders(self, order_hashes: list):
         self.assert_level_2_auth()
-        serialized = json.dumps(order_hashes, separators=(",", ":"))
+        serialized = json.dumps(order_hashes, separators=(",", ":"), ensure_ascii=False)
         headers = self._l2_headers(
             "DELETE", CANCEL_ORDERS, body=order_hashes, serialized_body=serialized
         )
@@ -891,7 +891,7 @@ class ClobClient:
             body["market"] = payload.market
         if payload.asset_id:
             body["asset_id"] = payload.asset_id
-        serialized = json.dumps(body, separators=(",", ":"))
+        serialized = json.dumps(body, separators=(",", ":"), ensure_ascii=False)
         headers = self._l2_headers(
             "DELETE", CANCEL_MARKET_ORDERS, body=body, serialized_body=serialized
         )
@@ -908,7 +908,7 @@ class ClobClient:
     def are_orders_scoring(self, params: OrdersScoringParams = None):
         self.assert_level_2_auth()
         order_ids = params.orderIds if params else []
-        serialized = json.dumps(order_ids, separators=(",", ":"))
+        serialized = json.dumps(order_ids, separators=(",", ":"), ensure_ascii=False)
         headers = self._l2_headers(
             "POST", ARE_ORDERS_SCORING, body=order_ids, serialized_body=serialized
         )
@@ -1006,7 +1006,7 @@ class ClobClient:
     def delete_readonly_api_key(self, key: str):
         self.assert_level_2_auth()
         body = {"key": key}
-        serialized = json.dumps(body, separators=(",", ":"))
+        serialized = json.dumps(body, separators=(",", ":"), ensure_ascii=False)
         headers = self._l2_headers("DELETE", DELETE_READONLY_API_KEY, body=body, serialized_body=serialized)
         return self._delete(f"{self.host}{DELETE_READONLY_API_KEY}", headers=headers, data=serialized)
 
@@ -1074,7 +1074,7 @@ class ClobClient:
         error = resp.get("error")
         if not error:
             return False
-        message = error if isinstance(error, str) else json.dumps(error)
+        message = error if isinstance(error, str) else json.dumps(error, ensure_ascii=False)
         return ORDER_VERSION_MISMATCH_ERROR in message
 
     def _retry_on_version_update(self, func):

--- a/py_clob_client_v2/client.py
+++ b/py_clob_client_v2/client.py
@@ -1074,7 +1074,7 @@ class ClobClient:
         error = resp.get("error")
         if not error:
             return False
-        message = error if isinstance(error, str) else json.dumps(error, ensure_ascii=False)
+        message = error if isinstance(error, str) else json.dumps(error, separators=(",", ":"), ensure_ascii=False)
         return ORDER_VERSION_MISMATCH_ERROR in message
 
     def _retry_on_version_update(self, func):

--- a/py_clob_client_v2/client.py
+++ b/py_clob_client_v2/client.py
@@ -703,7 +703,8 @@ class ClobClient:
         )
         version = self.__resolve_version()
 
-        fee_rate_bps = self.__resolve_fee_rate_bps(token_id) if version == 1 else None
+        user_fee_rate_bps = getattr(order_args, "fee_rate_bps", None) or None
+        fee_rate_bps = self.__resolve_fee_rate_bps(token_id, user_fee_rate_bps) if version == 1 else None
 
         return self.builder.build_order(
             order_args,
@@ -770,7 +771,8 @@ class ClobClient:
         )
         version = self.__resolve_version()
 
-        fee_rate_bps = self.__resolve_fee_rate_bps(token_id) if version == 1 else None
+        user_fee_rate_bps = getattr(order_args, "fee_rate_bps", None) or None
+        fee_rate_bps = self.__resolve_fee_rate_bps(token_id, user_fee_rate_bps) if version == 1 else None
 
         return self.builder.build_market_order(
             order_args,

--- a/py_clob_client_v2/client.py
+++ b/py_clob_client_v2/client.py
@@ -163,6 +163,7 @@ class ClobClient:
         # Caches
         self.__tick_sizes: dict = {}
         self.__neg_risk: dict = {}
+        self.__fee_rates: dict = {}
         self.__fee_infos: dict = {}
         self.__builder_fee_rates: dict = {}
         self.__token_condition_map: dict = {}
@@ -347,19 +348,15 @@ class ClobClient:
         self.__neg_risk[token_id] = result["neg_risk"]
         return self.__neg_risk[token_id]
 
-    def get_fee_rate_bps(self, token_id: str) -> float:
-        if token_id in self.__fee_infos:
-            return self.__fee_infos[token_id].rate
-
-        if token_id in self.__token_condition_map:
-            self.get_clob_market_info(self.__token_condition_map[token_id])
-            return self.__fee_infos[token_id].rate
+    def get_fee_rate_bps(self, token_id: str) -> int:
+        if token_id in self.__fee_rates:
+            return self.__fee_rates[token_id]
 
         result = self._get(
             f"{self.host}{GET_FEE_RATE}", params={"token_id": token_id}
         )
-        self.__fee_infos[token_id] = FeeInfo(rate=result["base_fee"], exponent=0.0)
-        return self.__fee_infos[token_id].rate
+        self.__fee_rates[token_id] = result.get("base_fee") or 0
+        return self.__fee_rates[token_id]
 
     def get_fee_exponent(self, token_id: str) -> float:
         if token_id in self.__fee_infos:
@@ -689,10 +686,9 @@ class ClobClient:
 
         token_id = order_args.token_id
 
-        if not options or not options.tick_size:
-            raise PolyException("tick_size is required in options")
-
-        tick_size = options.tick_size
+        tick_size = self.__resolve_tick_size(
+            token_id, options.tick_size if options else None
+        )
 
         if not price_valid(order_args.price, tick_size):
             ts = float(tick_size)
@@ -707,10 +703,13 @@ class ClobClient:
         )
         version = self.__resolve_version()
 
+        fee_rate_bps = self.__resolve_fee_rate_bps(token_id) if version == 1 else None
+
         return self.builder.build_order(
             order_args,
             CreateOrderOptions(tick_size=tick_size, neg_risk=neg_risk),
             version=version,
+            fee_rate_bps=fee_rate_bps,
         )
 
     def create_market_order(
@@ -771,10 +770,13 @@ class ClobClient:
         )
         version = self.__resolve_version()
 
+        fee_rate_bps = self.__resolve_fee_rate_bps(token_id) if version == 1 else None
+
         return self.builder.build_market_order(
             order_args,
             CreateOrderOptions(tick_size=tick_size, neg_risk=neg_risk),
             version=version,
+            fee_rate_bps=fee_rate_bps,
         )
 
     def create_and_post_order(
@@ -1020,6 +1022,19 @@ class ClobClient:
                 )
             return tick_size
         return min_tick_size
+
+    def __resolve_fee_rate_bps(self, token_id: str, user_fee_rate_bps: int = None) -> int:
+        market_fee_rate_bps = self.get_fee_rate_bps(token_id)
+        if (
+            market_fee_rate_bps > 0
+            and user_fee_rate_bps is not None
+            and user_fee_rate_bps != market_fee_rate_bps
+        ):
+            raise PolyException(
+                f"invalid user provided fee rate: {user_fee_rate_bps}, "
+                f"fee rate for the market must be {market_fee_rate_bps}"
+            )
+        return market_fee_rate_bps
 
     def __resolve_version(self, force_update: bool = False) -> int:
         if not force_update and self.__cached_version is not None:

--- a/py_clob_client_v2/clob_types.py
+++ b/py_clob_client_v2/clob_types.py
@@ -183,7 +183,7 @@ class OpenOrderParams:
 
 @dataclass
 class DropNotificationParams:
-    ids: list = None
+    ids: Optional[list] = None
 
 
 @dataclass
@@ -205,8 +205,8 @@ class OrderBookSummary:
     market: str = None
     asset_id: str = None
     timestamp: str = None
-    bids: list = None
-    asks: list = None
+    bids: Optional[list] = None
+    asks: Optional[list] = None
     min_order_size: str = None
     neg_risk: bool = None
     tick_size: str = None

--- a/py_clob_client_v2/config.py
+++ b/py_clob_client_v2/config.py
@@ -31,6 +31,6 @@ def get_contract_config(chain_id: int) -> ContractConfig:
 
     config = CONFIG.get(chain_id)
     if config is None:
-        raise Exception("Invalid chain_id: {}".format(chain_id))
+        raise Exception(f"Invalid chain_id: {chain_id}")
 
     return config

--- a/py_clob_client_v2/order_builder/builder.py
+++ b/py_clob_client_v2/order_builder/builder.py
@@ -126,6 +126,7 @@ class OrderBuilder:
         order_args: Union[OrderArgsV1, OrderArgsV2],
         options: CreateOrderOptions,
         version: int = 2,
+        fee_rate_bps: int = None,
     ) -> Union[SignedOrderV1, SignedOrderV2]:
         """
         Creates and signs a limit order.
@@ -152,6 +153,10 @@ class OrderBuilder:
                 if options.neg_risk
                 else contract_config.exchange
             )
+            resolved_fee_rate_bps = (
+                fee_rate_bps if fee_rate_bps is not None
+                else getattr(order_args, "fee_rate_bps", 0)
+            )
             order_data = OrderDataV1(
                 maker=self.funder,
                 taker=getattr(order_args, "taker", ZERO_ADDRESS),
@@ -159,7 +164,7 @@ class OrderBuilder:
                 makerAmount=str(maker_amount),
                 takerAmount=str(taker_amount),
                 side=side,
-                feeRateBps=str(getattr(order_args, "fee_rate_bps", 0)),
+                feeRateBps=str(resolved_fee_rate_bps),
                 nonce=str(getattr(order_args, "nonce", 0)),
                 signer=self.signer.address(),
                 expiration=str(order_args.expiration),
@@ -202,6 +207,7 @@ class OrderBuilder:
         order_args: Union[MarketOrderArgsV1, MarketOrderArgsV2],
         options: CreateOrderOptions,
         version: int = 2,
+        fee_rate_bps: int = None,
     ) -> Union[SignedOrderV1, SignedOrderV2]:
         """
         Creates and signs a market order.
@@ -228,6 +234,10 @@ class OrderBuilder:
                 if options.neg_risk
                 else contract_config.exchange
             )
+            resolved_fee_rate_bps = (
+                fee_rate_bps if fee_rate_bps is not None
+                else getattr(order_args, "fee_rate_bps", 0)
+            )
             order_data = OrderDataV1(
                 maker=self.funder,
                 taker=getattr(order_args, "taker", ZERO_ADDRESS),
@@ -235,7 +245,7 @@ class OrderBuilder:
                 makerAmount=str(maker_amount),
                 takerAmount=str(taker_amount),
                 side=side,
-                feeRateBps=str(getattr(order_args, "fee_rate_bps", 0)),
+                feeRateBps=str(resolved_fee_rate_bps),
                 nonce=str(getattr(order_args, "nonce", 0)),
                 signer=self.signer.address(),
                 expiration="0",

--- a/tests/order_builder/test_builder.py
+++ b/tests/order_builder/test_builder.py
@@ -2,12 +2,14 @@ from unittest import TestCase
 
 from py_clob_client_v2.clob_types import (
     CreateOrderOptions,
+    MarketOrderArgsV1,
     MarketOrderArgsV2,
+    OrderArgsV1,
     OrderArgsV2,
     OrderSummary,
     OrderType,
 )
-from py_clob_client_v2.constants import AMOY, BYTES32_ZERO
+from py_clob_client_v2.constants import AMOY, BYTES32_ZERO, ZERO_ADDRESS
 from py_clob_client_v2.order_builder.builder import OrderBuilder, ROUNDING_CONFIG
 from py_clob_client_v2.order_builder.constants import BUY, SELL
 from py_clob_client_v2.order_builder.helpers import decimal_places, round_down, round_normal
@@ -444,6 +446,22 @@ class TestOrderBuilder(TestCase):
                 price = round_normal(price + delta_price, 4)
             size = round_normal(size + delta_size, 2)
 
+    def _assert_signed_order_v1(self, order):
+        self.assertIsNotNone(order.salt)
+        self.assertIsNotNone(order.maker)
+        self.assertIsNotNone(order.signer)
+        self.assertIsNotNone(order.tokenId)
+        self.assertIsNotNone(order.makerAmount)
+        self.assertIsNotNone(order.takerAmount)
+        self.assertIsNotNone(order.signature)
+        self.assertIsNotNone(order.feeRateBps)
+        self.assertIsNotNone(order.nonce)
+        self.assertIsNotNone(order.taker)
+        # V1 has no timestamp, metadata, or builder
+        self.assertFalse(hasattr(order, "timestamp"))
+        self.assertFalse(hasattr(order, "metadata"))
+        self.assertFalse(hasattr(order, "builder"))
+
     def _assert_signed_order_v2(self, order):
         self.assertIsNotNone(order.salt)
         self.assertIsNotNone(order.maker)
@@ -638,6 +656,60 @@ class TestOrderBuilder(TestCase):
                 token_id=TOKEN_ID, amount=50, side=BUY, price=0.5, builder_code=builder_code
             ),
             CreateOrderOptions(tick_size="0.1", neg_risk=False),
+        )
+        self._assert_signed_order_v2(order)
+        self.assertEqual(order.builder, builder_code)
+
+    def test_build_order_v1_has_fee_rate_bps_nonce_taker(self):
+        builder = OrderBuilder(signer)
+        order = builder.build_order(
+            OrderArgsV1(token_id=TOKEN_ID, price=0.5, size=21.04, side=BUY, nonce=7),
+            CreateOrderOptions(tick_size="0.01", neg_risk=False),
+            version=1,
+            fee_rate_bps=1000,
+        )
+        self._assert_signed_order_v1(order)
+        self.assertEqual(order.feeRateBps, "1000")
+        self.assertEqual(order.nonce, "7")
+        self.assertEqual(order.taker, ZERO_ADDRESS)
+
+    def test_build_order_v2_has_no_fee_rate_bps_nonce(self):
+        builder = OrderBuilder(signer)
+        builder_code = "0x" + "ab" * 32
+        order = builder.build_order(
+            OrderArgsV2(
+                token_id=TOKEN_ID, price=0.5, size=21.04, side=BUY,
+                builder_code=builder_code, expiration=1234567,
+            ),
+            CreateOrderOptions(tick_size="0.01", neg_risk=False),
+            version=2,
+        )
+        self._assert_signed_order_v2(order)
+        self.assertEqual(order.builder, builder_code)
+        self.assertEqual(order.expiration, "1234567")
+
+    def test_build_market_order_v1_has_fee_rate_bps_nonce_taker(self):
+        builder = OrderBuilder(signer)
+        order = builder.build_market_order(
+            MarketOrderArgsV1(token_id=TOKEN_ID, amount=21.04, side=BUY, price=0.5, nonce=3),
+            CreateOrderOptions(tick_size="0.01", neg_risk=False),
+            version=1,
+            fee_rate_bps=500,
+        )
+        self._assert_signed_order_v1(order)
+        self.assertEqual(order.feeRateBps, "500")
+        self.assertEqual(order.nonce, "3")
+        self.assertEqual(order.taker, ZERO_ADDRESS)
+
+    def test_build_market_order_v2_has_no_fee_rate_bps_nonce(self):
+        builder = OrderBuilder(signer)
+        builder_code = "0x" + "ef" * 32
+        order = builder.build_market_order(
+            MarketOrderArgsV2(
+                token_id=TOKEN_ID, amount=21.04, side=BUY, price=0.5, builder_code=builder_code
+            ),
+            CreateOrderOptions(tick_size="0.01", neg_risk=False),
+            version=2,
         )
         self._assert_signed_order_v2(order)
         self.assertEqual(order.builder, builder_code)

--- a/tests/test_client_fee_cache.py
+++ b/tests/test_client_fee_cache.py
@@ -1,13 +1,3 @@
-"""
-Tests for FeeInfo cache correctness in ClobClient.
-
-Aligned with TypeScript clob-client-v2 behavior:
-- getClobMarketInfo always sets feeInfos[tokenId] = FeeInfo(rate=fd?.r ?? 0, exponent=fd?.e ?? 0)
-- Cache presence check is `token_id in __fee_infos` (not None-checking values)
-- _ensureMarketInfoCached returns early if token_id in __fee_infos
-- GET_FEE_RATE fallback sets FeeInfo(rate=X, exponent=0) — overwrites
-"""
-
 from unittest.mock import MagicMock, patch
 import pytest
 
@@ -46,60 +36,53 @@ class TestFeeInfoDefaults:
 
 
 class TestGetFeeRateBps:
-    def test_returns_cached_rate_from_market_info(self):
+    def test_returns_cached_rate_from_fee_rates(self):
+        """Uses __fee_rates cache (separate from __fee_infos)."""
+        client = _make_client()
+        client._ClobClient__fee_rates[TOKEN_ID] = 200
+        with patch.object(client, "_get") as mock_get:
+            rate = client.get_fee_rate_bps(TOKEN_ID)
+        assert rate == 200
+        mock_get.assert_not_called()
+
+    def test_does_not_use_fee_infos_as_cache(self):
+        """Even if __fee_infos is populated, get_fee_rate_bps fetches from endpoint."""
         client = _make_client()
         _inject_market_info(client, TOKEN_ID, rate=0.02, exponent=2.0)
-        assert client.get_fee_rate_bps(TOKEN_ID) == 0.02
-
-    def test_cache_hit_any_fee_info_entry(self):
-        """Any entry in __fee_infos satisfies the cache check."""
-        client = _make_client()
-        client._ClobClient__fee_infos[TOKEN_ID] = FeeInfo(rate=0.03, exponent=0.0)
-        assert client.get_fee_rate_bps(TOKEN_ID) == 0.03
-
-    def test_get_fee_rate_via_condition_map(self):
-        """Falls through to getClobMarketInfo when token is in condition_map but not fee_infos."""
-        client = _make_client()
-        client._ClobClient__token_condition_map[TOKEN_ID] = CONDITION_ID
-
-        clob_market_response = {
-            "t": [{"t": TOKEN_ID}],
-            "mts": "0.01",
-            "nr": False,
-            "fd": {"r": 0.025, "e": 1.0},
-        }
-        with patch.object(client, "_get", return_value=clob_market_response):
+        with patch.object(client, "_get", return_value={"base_fee": 200}) as mock_get:
             rate = client.get_fee_rate_bps(TOKEN_ID)
-
-        assert rate == 0.025
-
-    def test_get_fee_rate_via_get_fee_rate_endpoint(self):
-        """Falls through to GET_FEE_RATE when token not in fee_infos or condition_map."""
-        client = _make_client()
-        with patch.object(client, "_get", return_value={"base_fee": 0.05}) as mock_get:
-            rate = client.get_fee_rate_bps(TOKEN_ID)
-        assert rate == 0.05
+        assert rate == 200
         mock_get.assert_called_once()
 
-    def test_get_fee_rate_endpoint_sets_exponent_zero(self):
-        """GET_FEE_RATE fallback sets exponent to 0 (no exponent from that endpoint)."""
+    def test_get_fee_rate_via_get_fee_rate_endpoint(self):
+        """Falls through to GET_FEE_RATE when token not in __fee_rates."""
         client = _make_client()
-        with patch.object(client, "_get", return_value={"base_fee": 0.04}):
+        with patch.object(client, "_get", return_value={"base_fee": 200}) as mock_get:
+            rate = client.get_fee_rate_bps(TOKEN_ID)
+        assert rate == 200
+        mock_get.assert_called_once()
+
+    def test_stores_in_fee_rates_cache_not_fee_infos(self):
+        """Result is cached in __fee_rates; __fee_infos is not touched."""
+        client = _make_client()
+        with patch.object(client, "_get", return_value={"base_fee": 150}):
             client.get_fee_rate_bps(TOKEN_ID)
+        assert client._ClobClient__fee_rates[TOKEN_ID] == 150
+        assert TOKEN_ID not in client._ClobClient__fee_infos
 
-        fi = client._ClobClient__fee_infos[TOKEN_ID]
-        assert fi.rate == 0.04
-        assert fi.exponent == 0.0
-
-    def test_no_refetch_after_cache_hit(self):
-        """Once in fee_infos, no further _get calls for rate."""
+    def test_no_refetch_after_fee_rates_cache_hit(self):
+        """Once in __fee_rates, no further _get calls."""
         client = _make_client()
-        _inject_market_info(client, TOKEN_ID, rate=0.02, exponent=2.0)
-
+        client._ClobClient__fee_rates[TOKEN_ID] = 100
         with patch.object(client, "_get") as mock_get:
             client.get_fee_rate_bps(TOKEN_ID)
-
         mock_get.assert_not_called()
+
+    def test_zero_when_base_fee_missing(self):
+        client = _make_client()
+        with patch.object(client, "_get", return_value={}):
+            rate = client.get_fee_rate_bps(TOKEN_ID)
+        assert rate == 0
 
 
 class TestGetFeeExponent:
@@ -177,15 +160,17 @@ class TestGetClobMarketInfo:
         assert fi.exponent == 2.0
 
     def test_no_repeated_fetch_after_clob_market_info(self):
-        """After getClobMarketInfo populates fee_infos, get_fee_rate_bps should not re-fetch."""
+        """After getClobMarketInfo populates fee_infos, get_fee_exponent does not re-fetch.
+        get_fee_rate_bps uses its own __fee_rates cache and fetches from endpoint if not set."""
         client = _make_client()
         _inject_market_info(client, TOKEN_ID, rate=0.02, exponent=2.0)
 
-        with patch.object(client, "_get") as mock_get:
-            client.get_fee_rate_bps(TOKEN_ID)
-            client.get_fee_exponent(TOKEN_ID)
+        with patch.object(client, "_get", return_value={"base_fee": 200}):
+            fee_rate = client.get_fee_rate_bps(TOKEN_ID)
+            fee_exponent = client.get_fee_exponent(TOKEN_ID)
 
-        mock_get.assert_not_called()
+        assert fee_rate == 200      # fetched from endpoint (separate __fee_rates cache)
+        assert fee_exponent == 2.0  # served from __fee_infos without re-fetch
 
 
 class TestEnsureMarketInfoCached:

--- a/tests/test_client_fee_cache.py
+++ b/tests/test_client_fee_cache.py
@@ -1,5 +1,5 @@
+from unittest import TestCase
 from unittest.mock import MagicMock, patch
-import pytest
 
 from py_clob_client_v2.client import ClobClient
 from py_clob_client_v2.clob_types import FeeInfo
@@ -23,55 +23,50 @@ def _inject_market_info(client: ClobClient, token_id: str, rate: float, exponent
     client._ClobClient__token_condition_map[token_id] = CONDITION_ID
 
 
-class TestFeeInfoDefaults:
+class TestFeeInfoDefaults(TestCase):
     def test_fee_info_defaults_are_zero(self):
         fi = FeeInfo()
-        assert fi.rate == 0.0
-        assert fi.exponent == 0.0
+        self.assertEqual(fi.rate, 0.0)
+        self.assertEqual(fi.exponent, 0.0)
 
     def test_fee_info_explicit_values(self):
         fi = FeeInfo(rate=0.02, exponent=2.0)
-        assert fi.rate == 0.02
-        assert fi.exponent == 2.0
+        self.assertEqual(fi.rate, 0.02)
+        self.assertEqual(fi.exponent, 2.0)
 
 
-class TestGetFeeRateBps:
+class TestGetFeeRateBps(TestCase):
     def test_returns_cached_rate_from_fee_rates(self):
-        """Uses __fee_rates cache (separate from __fee_infos)."""
         client = _make_client()
         client._ClobClient__fee_rates[TOKEN_ID] = 200
         with patch.object(client, "_get") as mock_get:
             rate = client.get_fee_rate_bps(TOKEN_ID)
-        assert rate == 200
+        self.assertEqual(rate, 200)
         mock_get.assert_not_called()
 
     def test_does_not_use_fee_infos_as_cache(self):
-        """Even if __fee_infos is populated, get_fee_rate_bps fetches from endpoint."""
         client = _make_client()
         _inject_market_info(client, TOKEN_ID, rate=0.02, exponent=2.0)
         with patch.object(client, "_get", return_value={"base_fee": 200}) as mock_get:
             rate = client.get_fee_rate_bps(TOKEN_ID)
-        assert rate == 200
+        self.assertEqual(rate, 200)
         mock_get.assert_called_once()
 
     def test_get_fee_rate_via_get_fee_rate_endpoint(self):
-        """Falls through to GET_FEE_RATE when token not in __fee_rates."""
         client = _make_client()
         with patch.object(client, "_get", return_value={"base_fee": 200}) as mock_get:
             rate = client.get_fee_rate_bps(TOKEN_ID)
-        assert rate == 200
+        self.assertEqual(rate, 200)
         mock_get.assert_called_once()
 
     def test_stores_in_fee_rates_cache_not_fee_infos(self):
-        """Result is cached in __fee_rates; __fee_infos is not touched."""
         client = _make_client()
         with patch.object(client, "_get", return_value={"base_fee": 150}):
             client.get_fee_rate_bps(TOKEN_ID)
-        assert client._ClobClient__fee_rates[TOKEN_ID] == 150
-        assert TOKEN_ID not in client._ClobClient__fee_infos
+        self.assertEqual(client._ClobClient__fee_rates[TOKEN_ID], 150)
+        self.assertNotIn(TOKEN_ID, client._ClobClient__fee_infos)
 
     def test_no_refetch_after_fee_rates_cache_hit(self):
-        """Once in __fee_rates, no further _get calls."""
         client = _make_client()
         client._ClobClient__fee_rates[TOKEN_ID] = 100
         with patch.object(client, "_get") as mock_get:
@@ -82,21 +77,19 @@ class TestGetFeeRateBps:
         client = _make_client()
         with patch.object(client, "_get", return_value={}):
             rate = client.get_fee_rate_bps(TOKEN_ID)
-        assert rate == 0
+        self.assertEqual(rate, 0)
 
 
-class TestGetFeeExponent:
+class TestGetFeeExponent(TestCase):
     def test_returns_cached_exponent_from_market_info(self):
         client = _make_client()
         _inject_market_info(client, TOKEN_ID, rate=0.02, exponent=2.0)
-        assert client.get_fee_exponent(TOKEN_ID) == 2.0
+        self.assertEqual(client.get_fee_exponent(TOKEN_ID), 2.0)
 
     def test_cache_hit_any_fee_info_entry(self):
-        """Any entry in __fee_infos satisfies the cache check (returns stored exponent)."""
         client = _make_client()
-        # Simulate GET_FEE_RATE fallback: exponent=0
         client._ClobClient__fee_infos[TOKEN_ID] = FeeInfo(rate=0.03, exponent=0.0)
-        assert client.get_fee_exponent(TOKEN_ID) == 0.0
+        self.assertEqual(client.get_fee_exponent(TOKEN_ID), 0.0)
 
     def test_fetches_market_info_when_not_cached(self):
         client = _make_client()
@@ -111,23 +104,21 @@ class TestGetFeeExponent:
         with patch.object(client, "_get", return_value=clob_market_response):
             exponent = client.get_fee_exponent(TOKEN_ID)
 
-        assert exponent == 4.0
+        self.assertEqual(exponent, 4.0)
 
     def test_no_refetch_after_cache_hit(self):
-        """Once in fee_infos, no further _get calls for exponent."""
         client = _make_client()
         _inject_market_info(client, TOKEN_ID, rate=0.02, exponent=1.5)
 
         with patch.object(client, "_get") as mock_get:
             exponent = client.get_fee_exponent(TOKEN_ID)
 
-        assert exponent == 1.5
+        self.assertEqual(exponent, 1.5)
         mock_get.assert_not_called()
 
 
-class TestGetClobMarketInfo:
+class TestGetClobMarketInfo(TestCase):
     def test_sets_fee_info_with_defaults_when_fd_missing(self):
-        """When fd is missing from response, fee info defaults to rate=0, exponent=0."""
         client = _make_client()
 
         response = {
@@ -139,9 +130,9 @@ class TestGetClobMarketInfo:
             client.get_clob_market_info(CONDITION_ID)
 
         fi = client._ClobClient__fee_infos.get(TOKEN_ID)
-        assert fi is not None
-        assert fi.rate == 0.0
-        assert fi.exponent == 0.0
+        self.assertIsNotNone(fi)
+        self.assertEqual(fi.rate, 0.0)
+        self.assertEqual(fi.exponent, 0.0)
 
     def test_sets_fee_info_from_fd(self):
         client = _make_client()
@@ -156,12 +147,10 @@ class TestGetClobMarketInfo:
             client.get_clob_market_info(CONDITION_ID)
 
         fi = client._ClobClient__fee_infos[TOKEN_ID]
-        assert fi.rate == 0.03
-        assert fi.exponent == 2.0
+        self.assertEqual(fi.rate, 0.03)
+        self.assertEqual(fi.exponent, 2.0)
 
     def test_no_repeated_fetch_after_clob_market_info(self):
-        """After getClobMarketInfo populates fee_infos, get_fee_exponent does not re-fetch.
-        get_fee_rate_bps uses its own __fee_rates cache and fetches from endpoint if not set."""
         client = _make_client()
         _inject_market_info(client, TOKEN_ID, rate=0.02, exponent=2.0)
 
@@ -169,13 +158,12 @@ class TestGetClobMarketInfo:
             fee_rate = client.get_fee_rate_bps(TOKEN_ID)
             fee_exponent = client.get_fee_exponent(TOKEN_ID)
 
-        assert fee_rate == 200      # fetched from endpoint (separate __fee_rates cache)
-        assert fee_exponent == 2.0  # served from __fee_infos without re-fetch
+        self.assertEqual(fee_rate, 200)
+        self.assertEqual(fee_exponent, 2.0)
 
 
-class TestEnsureMarketInfoCached:
+class TestEnsureMarketInfoCached(TestCase):
     def test_no_refetch_when_fee_infos_has_token(self):
-        """Returns immediately if token already in __fee_infos."""
         client = _make_client()
         _inject_market_info(client, TOKEN_ID, rate=0.02, exponent=2.0)
 
@@ -197,12 +185,10 @@ class TestEnsureMarketInfoCached:
         with patch.object(client, "_get", return_value=clob_market_response):
             client._ClobClient__ensure_market_info_cached(TOKEN_ID)
 
-        assert TOKEN_ID in client._ClobClient__fee_infos
+        self.assertIn(TOKEN_ID, client._ClobClient__fee_infos)
 
     def test_get_fee_rate_endpoint_entry_blocks_refetch(self):
-        """If GET_FEE_RATE stored a FeeInfo, ensureMarketInfoCached returns early."""
         client = _make_client()
-        # Simulate GET_FEE_RATE fallback result
         client._ClobClient__fee_infos[TOKEN_ID] = FeeInfo(rate=0.05, exponent=0.0)
         client._ClobClient__token_condition_map[TOKEN_ID] = CONDITION_ID
 

--- a/tests/test_fee_calculations.py
+++ b/tests/test_fee_calculations.py
@@ -1,0 +1,225 @@
+import pytest
+from py_clob_client_v2.utilities import adjust_market_buy_amount
+
+
+def calculate_platform_fee(amount_usd: float, price: float, fee_rate: float, fee_exponent: float) -> float:
+    platform_fee_rate = fee_rate * (price * (1 - price)) ** fee_exponent
+    return (amount_usd / price) * platform_fee_rate
+
+
+def calculate_builder_fee(amount_usd: float, builder_taker_fee_rate: float) -> float:
+    return amount_usd * builder_taker_fee_rate
+
+
+class TestPlatformFee:
+    fee_rate = 0.25
+    fee_exponent = 2
+    contracts = 100
+
+    def test_price_0_5(self):
+        price = 0.5
+        assert calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent) == pytest.approx(1.5625, abs=1e-6)
+
+    def test_price_0_3(self):
+        price = 0.3
+        assert calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent) == pytest.approx(1.1025, abs=1e-6)
+
+    def test_price_0_1(self):
+        price = 0.1
+        assert calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent) == pytest.approx(0.2025, abs=1e-6)
+
+    def test_price_0_05(self):
+        price = 0.05
+        assert calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent) == pytest.approx(0.05640625, abs=1e-6)
+
+    def test_price_0_01(self):
+        price = 0.01
+        assert calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent) == pytest.approx(0.00245025, abs=1e-6)
+
+    def test_price_0_7_symmetric_with_0_3(self):
+        price = 0.7
+        assert calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent) == pytest.approx(1.1025, abs=1e-6)
+
+    def test_price_0_9_symmetric_with_0_1(self):
+        price = 0.9
+        assert calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent) == pytest.approx(0.2025, abs=1e-6)
+
+    def test_price_0_95_symmetric_with_0_05(self):
+        price = 0.95
+        assert calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent) == pytest.approx(0.05640625, abs=1e-6)
+
+    def test_price_0_99_symmetric_with_0_01(self):
+        price = 0.99
+        assert calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent) == pytest.approx(0.00245025, abs=1e-6)
+
+    def test_price_0_5_c_125_5(self):
+        price = 0.5
+        c = 125.5
+        assert calculate_platform_fee(c * price, price, self.fee_rate, self.fee_exponent) == pytest.approx(1.9609375, abs=1e-6)
+
+
+class TestBuilderFee:
+    def test_1pct_100_tokens_at_50c(self):
+        price = 0.5
+        contracts = 100
+        builder_taker_fee_rate = 0.01
+        assert calculate_builder_fee(contracts * price, builder_taker_fee_rate) == pytest.approx(0.5, abs=1e-6)
+
+    def test_5pct_200_tokens_at_75c(self):
+        price = 0.75
+        contracts = 200
+        builder_taker_fee_rate = 0.05
+        assert calculate_builder_fee(contracts * price, builder_taker_fee_rate) == pytest.approx(7.5, abs=1e-6)
+
+
+class TestCombinedFee:
+    def test_matches_sum_of_separate_fees(self):
+        price = 0.5
+        contracts = 100
+        fee_rate = 0.25
+        fee_exponent = 2
+        builder_taker_fee_rate = 0.01
+        amount_usd = contracts * price
+
+        platform_fee = calculate_platform_fee(amount_usd, price, fee_rate, fee_exponent)
+        builder_fee = calculate_builder_fee(amount_usd, builder_taker_fee_rate)
+
+        assert platform_fee == pytest.approx(1.5625, abs=1e-6)
+        assert builder_fee == pytest.approx(0.5, abs=1e-6)
+        assert platform_fee + builder_fee == pytest.approx(2.0625, abs=1e-6)
+
+
+class TestAdjustBuyAmountForFees:
+    fee_rate = 0.25
+    fee_exponent = 2
+
+    def test_no_adjustment_zero_fees(self):
+        amount = 50
+        result = adjust_market_buy_amount(amount, amount, 0.5, 0, 0, 0)
+        assert result == amount
+
+    def test_no_adjustment_balance_above_total_cost(self):
+        amount = 50
+        price = 0.5
+        platform_fee = calculate_platform_fee(amount, price, self.fee_rate, self.fee_exponent)
+        total_cost = amount + platform_fee
+        balance = total_cost + 1
+        result = adjust_market_buy_amount(amount, balance, price, self.fee_rate, self.fee_exponent, 0)
+        assert result == amount
+
+    def test_boundary_balance_equals_total_cost(self):
+        amount = 50
+        price = 0.5
+        platform_fee = calculate_platform_fee(amount, price, self.fee_rate, self.fee_exponent)
+        total_cost = amount + platform_fee
+        result = adjust_market_buy_amount(amount, total_cost, price, self.fee_rate, self.fee_exponent, 0)
+        platform_fee_rate = self.fee_rate * (price * (1 - price)) ** self.fee_exponent
+        expected = total_cost / (1 + platform_fee_rate / price)
+        assert result == pytest.approx(expected, rel=1e-10)
+
+    def test_platform_fee_only_adjusted_plus_fee_equals_amount(self):
+        amount = 50
+        price = 0.5
+        adjusted = adjust_market_buy_amount(amount, amount, price, self.fee_rate, self.fee_exponent, 0)
+        fee = calculate_platform_fee(adjusted, price, self.fee_rate, self.fee_exponent)
+        assert adjusted + fee == pytest.approx(amount, rel=1e-10)
+
+    def test_builder_fee_only_adjusted_plus_fee_equals_amount(self):
+        amount = 50
+        price = 0.5
+        builder_taker_fee_rate = 0.01
+        adjusted = adjust_market_buy_amount(amount, amount, price, 0, 0, builder_taker_fee_rate)
+        fee = calculate_builder_fee(adjusted, builder_taker_fee_rate)
+        assert adjusted + fee == pytest.approx(amount, rel=1e-10)
+
+    def test_platform_and_builder_fee_adjusted_plus_fees_equals_amount(self):
+        amount = 50
+        price = 0.5
+        builder_taker_fee_rate = 0.01
+        adjusted = adjust_market_buy_amount(amount, amount, price, self.fee_rate, self.fee_exponent, builder_taker_fee_rate)
+        platform_fee = calculate_platform_fee(adjusted, price, self.fee_rate, self.fee_exponent)
+        builder_fee = calculate_builder_fee(adjusted, builder_taker_fee_rate)
+        assert adjusted + platform_fee + builder_fee == pytest.approx(amount, rel=1e-10)
+
+    def test_adjusted_less_than_original(self):
+        amount = 50
+        adjusted = adjust_market_buy_amount(amount, amount, 0.5, self.fee_rate, self.fee_exponent, 0)
+        assert adjusted < amount
+
+    def test_price_0_3_platform_and_builder_adjusted_plus_fees_equals_amount(self):
+        amount = 30
+        price = 0.3
+        builder_taker_fee_rate = 0.02
+        adjusted = adjust_market_buy_amount(amount, amount, price, self.fee_rate, self.fee_exponent, builder_taker_fee_rate)
+        platform_fee = calculate_platform_fee(adjusted, price, self.fee_rate, self.fee_exponent)
+        builder_fee = calculate_builder_fee(adjusted, builder_taker_fee_rate)
+        assert adjusted + platform_fee + builder_fee == pytest.approx(amount, rel=1e-10)
+
+
+class TestProductionFeeRatesV1:
+    def _fee_v1(self, notional: float, bps: int) -> float:
+        return notional * bps / 10000
+
+    def test_sports_fees_v2_300bps(self):
+        assert self._fee_v1(100, 300) == pytest.approx(3.0, abs=1e-6)
+
+    def test_politics_tech_finance_mentions_400bps(self):
+        assert self._fee_v1(100, 400) == pytest.approx(4.0, abs=1e-6)
+
+    def test_culture_weather_general_economics_500bps(self):
+        assert self._fee_v1(100, 500) == pytest.approx(5.0, abs=1e-6)
+
+    def test_crypto_fees_v2_720bps(self):
+        assert self._fee_v1(100, 720) == pytest.approx(7.2, abs=1e-6)
+
+
+class TestProductionFeeRatesV2:
+    amount = 100
+
+    def test_sports_v2_rate_0_03_exp_1_price_0_5(self):
+        assert calculate_platform_fee(self.amount, 0.5, 0.03, 1) == pytest.approx(1.5, abs=1e-6)
+
+    def test_sports_v2_rate_0_03_exp_1_price_0_3(self):
+        assert calculate_platform_fee(self.amount, 0.3, 0.03, 1) == pytest.approx(2.1, abs=1e-6)
+
+    def test_sports_v2_rate_0_03_exp_1_price_0_7(self):
+        assert calculate_platform_fee(self.amount, 0.7, 0.03, 1) == pytest.approx(0.9, abs=1e-6)
+
+    def test_politics_rate_0_04_exp_1_price_0_5(self):
+        assert calculate_platform_fee(self.amount, 0.5, 0.04, 1) == pytest.approx(2.0, abs=1e-6)
+
+    def test_politics_rate_0_04_exp_1_price_0_3(self):
+        assert calculate_platform_fee(self.amount, 0.3, 0.04, 1) == pytest.approx(2.8, abs=1e-6)
+
+    def test_politics_rate_0_04_exp_1_price_0_7(self):
+        assert calculate_platform_fee(self.amount, 0.7, 0.04, 1) == pytest.approx(1.2, abs=1e-6)
+
+    def test_culture_rate_0_05_exp_1_price_0_5(self):
+        assert calculate_platform_fee(self.amount, 0.5, 0.05, 1) == pytest.approx(2.5, abs=1e-6)
+
+    def test_culture_rate_0_05_exp_1_price_0_3(self):
+        assert calculate_platform_fee(self.amount, 0.3, 0.05, 1) == pytest.approx(3.5, abs=1e-6)
+
+    def test_culture_rate_0_05_exp_1_price_0_7(self):
+        assert calculate_platform_fee(self.amount, 0.7, 0.05, 1) == pytest.approx(1.5, abs=1e-6)
+
+    def test_crypto_rate_0_072_exp_1_price_0_5(self):
+        assert calculate_platform_fee(self.amount, 0.5, 0.072, 1) == pytest.approx(3.6, abs=1e-6)
+
+    def test_crypto_rate_0_072_exp_1_price_0_3(self):
+        assert calculate_platform_fee(self.amount, 0.3, 0.072, 1) == pytest.approx(5.04, abs=1e-6)
+
+    def test_crypto_rate_0_072_exp_1_price_0_7(self):
+        assert calculate_platform_fee(self.amount, 0.7, 0.072, 1) == pytest.approx(2.16, abs=1e-6)
+
+    @pytest.mark.parametrize("rate,exponent,price", [
+        (0.03, 1, 0.3), (0.03, 1, 0.5), (0.03, 1, 0.7),
+        (0.04, 1, 0.3), (0.04, 1, 0.5), (0.04, 1, 0.7),
+        (0.05, 1, 0.3), (0.05, 1, 0.5), (0.05, 1, 0.7),
+        (0.072, 1, 0.3), (0.072, 1, 0.5), (0.072, 1, 0.7),
+    ])
+    def test_balance_equals_amount_adjusted_plus_fee_equals_balance(self, rate, exponent, price):
+        amount = 100
+        adjusted = adjust_market_buy_amount(amount, amount, price, rate, exponent, 0)
+        fee = calculate_platform_fee(adjusted, price, rate, exponent)
+        assert adjusted + fee == pytest.approx(amount, rel=1e-10)

--- a/tests/test_fee_calculations.py
+++ b/tests/test_fee_calculations.py
@@ -1,4 +1,4 @@
-import pytest
+import unittest
 from py_clob_client_v2.utilities import adjust_market_buy_amount
 
 
@@ -11,68 +11,68 @@ def calculate_builder_fee(amount_usd: float, builder_taker_fee_rate: float) -> f
     return amount_usd * builder_taker_fee_rate
 
 
-class TestPlatformFee:
+class TestPlatformFee(unittest.TestCase):
     fee_rate = 0.25
     fee_exponent = 2
     contracts = 100
 
     def test_price_0_5(self):
         price = 0.5
-        assert calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent) == pytest.approx(1.5625, abs=1e-6)
+        self.assertAlmostEqual(calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent), 1.5625, delta=1e-6)
 
     def test_price_0_3(self):
         price = 0.3
-        assert calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent) == pytest.approx(1.1025, abs=1e-6)
+        self.assertAlmostEqual(calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent), 1.1025, delta=1e-6)
 
     def test_price_0_1(self):
         price = 0.1
-        assert calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent) == pytest.approx(0.2025, abs=1e-6)
+        self.assertAlmostEqual(calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent), 0.2025, delta=1e-6)
 
     def test_price_0_05(self):
         price = 0.05
-        assert calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent) == pytest.approx(0.05640625, abs=1e-6)
+        self.assertAlmostEqual(calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent), 0.05640625, delta=1e-6)
 
     def test_price_0_01(self):
         price = 0.01
-        assert calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent) == pytest.approx(0.00245025, abs=1e-6)
+        self.assertAlmostEqual(calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent), 0.00245025, delta=1e-6)
 
     def test_price_0_7_symmetric_with_0_3(self):
         price = 0.7
-        assert calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent) == pytest.approx(1.1025, abs=1e-6)
+        self.assertAlmostEqual(calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent), 1.1025, delta=1e-6)
 
     def test_price_0_9_symmetric_with_0_1(self):
         price = 0.9
-        assert calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent) == pytest.approx(0.2025, abs=1e-6)
+        self.assertAlmostEqual(calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent), 0.2025, delta=1e-6)
 
     def test_price_0_95_symmetric_with_0_05(self):
         price = 0.95
-        assert calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent) == pytest.approx(0.05640625, abs=1e-6)
+        self.assertAlmostEqual(calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent), 0.05640625, delta=1e-6)
 
     def test_price_0_99_symmetric_with_0_01(self):
         price = 0.99
-        assert calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent) == pytest.approx(0.00245025, abs=1e-6)
+        self.assertAlmostEqual(calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent), 0.00245025, delta=1e-6)
 
     def test_price_0_5_c_125_5(self):
         price = 0.5
         c = 125.5
-        assert calculate_platform_fee(c * price, price, self.fee_rate, self.fee_exponent) == pytest.approx(1.9609375, abs=1e-6)
+        self.assertAlmostEqual(calculate_platform_fee(c * price, price, self.fee_rate, self.fee_exponent), 1.9609375, delta=1e-6)
 
 
-class TestBuilderFee:
+class TestBuilderFee(unittest.TestCase):
     def test_1pct_100_tokens_at_50c(self):
         price = 0.5
         contracts = 100
         builder_taker_fee_rate = 0.01
-        assert calculate_builder_fee(contracts * price, builder_taker_fee_rate) == pytest.approx(0.5, abs=1e-6)
+        self.assertAlmostEqual(calculate_builder_fee(contracts * price, builder_taker_fee_rate), 0.5, delta=1e-6)
 
     def test_5pct_200_tokens_at_75c(self):
         price = 0.75
         contracts = 200
         builder_taker_fee_rate = 0.05
-        assert calculate_builder_fee(contracts * price, builder_taker_fee_rate) == pytest.approx(7.5, abs=1e-6)
+        self.assertAlmostEqual(calculate_builder_fee(contracts * price, builder_taker_fee_rate), 7.5, delta=1e-6)
 
 
-class TestCombinedFee:
+class TestCombinedFee(unittest.TestCase):
     def test_matches_sum_of_separate_fees(self):
         price = 0.5
         contracts = 100
@@ -84,19 +84,19 @@ class TestCombinedFee:
         platform_fee = calculate_platform_fee(amount_usd, price, fee_rate, fee_exponent)
         builder_fee = calculate_builder_fee(amount_usd, builder_taker_fee_rate)
 
-        assert platform_fee == pytest.approx(1.5625, abs=1e-6)
-        assert builder_fee == pytest.approx(0.5, abs=1e-6)
-        assert platform_fee + builder_fee == pytest.approx(2.0625, abs=1e-6)
+        self.assertAlmostEqual(platform_fee, 1.5625, delta=1e-6)
+        self.assertAlmostEqual(builder_fee, 0.5, delta=1e-6)
+        self.assertAlmostEqual(platform_fee + builder_fee, 2.0625, delta=1e-6)
 
 
-class TestAdjustBuyAmountForFees:
+class TestAdjustBuyAmountForFees(unittest.TestCase):
     fee_rate = 0.25
     fee_exponent = 2
 
     def test_no_adjustment_zero_fees(self):
         amount = 50
         result = adjust_market_buy_amount(amount, amount, 0.5, 0, 0, 0)
-        assert result == amount
+        self.assertEqual(result, amount)
 
     def test_no_adjustment_balance_above_total_cost(self):
         amount = 50
@@ -105,7 +105,7 @@ class TestAdjustBuyAmountForFees:
         total_cost = amount + platform_fee
         balance = total_cost + 1
         result = adjust_market_buy_amount(amount, balance, price, self.fee_rate, self.fee_exponent, 0)
-        assert result == amount
+        self.assertEqual(result, amount)
 
     def test_boundary_balance_equals_total_cost(self):
         amount = 50
@@ -115,14 +115,14 @@ class TestAdjustBuyAmountForFees:
         result = adjust_market_buy_amount(amount, total_cost, price, self.fee_rate, self.fee_exponent, 0)
         platform_fee_rate = self.fee_rate * (price * (1 - price)) ** self.fee_exponent
         expected = total_cost / (1 + platform_fee_rate / price)
-        assert result == pytest.approx(expected, rel=1e-10)
+        self.assertAlmostEqual(result, expected, places=9)
 
     def test_platform_fee_only_adjusted_plus_fee_equals_amount(self):
         amount = 50
         price = 0.5
         adjusted = adjust_market_buy_amount(amount, amount, price, self.fee_rate, self.fee_exponent, 0)
         fee = calculate_platform_fee(adjusted, price, self.fee_rate, self.fee_exponent)
-        assert adjusted + fee == pytest.approx(amount, rel=1e-10)
+        self.assertAlmostEqual(adjusted + fee, amount, places=9)
 
     def test_builder_fee_only_adjusted_plus_fee_equals_amount(self):
         amount = 50
@@ -130,7 +130,7 @@ class TestAdjustBuyAmountForFees:
         builder_taker_fee_rate = 0.01
         adjusted = adjust_market_buy_amount(amount, amount, price, 0, 0, builder_taker_fee_rate)
         fee = calculate_builder_fee(adjusted, builder_taker_fee_rate)
-        assert adjusted + fee == pytest.approx(amount, rel=1e-10)
+        self.assertAlmostEqual(adjusted + fee, amount, places=9)
 
     def test_platform_and_builder_fee_adjusted_plus_fees_equals_amount(self):
         amount = 50
@@ -139,12 +139,12 @@ class TestAdjustBuyAmountForFees:
         adjusted = adjust_market_buy_amount(amount, amount, price, self.fee_rate, self.fee_exponent, builder_taker_fee_rate)
         platform_fee = calculate_platform_fee(adjusted, price, self.fee_rate, self.fee_exponent)
         builder_fee = calculate_builder_fee(adjusted, builder_taker_fee_rate)
-        assert adjusted + platform_fee + builder_fee == pytest.approx(amount, rel=1e-10)
+        self.assertAlmostEqual(adjusted + platform_fee + builder_fee, amount, places=9)
 
     def test_adjusted_less_than_original(self):
         amount = 50
         adjusted = adjust_market_buy_amount(amount, amount, 0.5, self.fee_rate, self.fee_exponent, 0)
-        assert adjusted < amount
+        self.assertLess(adjusted, amount)
 
     def test_price_0_3_platform_and_builder_adjusted_plus_fees_equals_amount(self):
         amount = 30
@@ -153,73 +153,75 @@ class TestAdjustBuyAmountForFees:
         adjusted = adjust_market_buy_amount(amount, amount, price, self.fee_rate, self.fee_exponent, builder_taker_fee_rate)
         platform_fee = calculate_platform_fee(adjusted, price, self.fee_rate, self.fee_exponent)
         builder_fee = calculate_builder_fee(adjusted, builder_taker_fee_rate)
-        assert adjusted + platform_fee + builder_fee == pytest.approx(amount, rel=1e-10)
+        self.assertAlmostEqual(adjusted + platform_fee + builder_fee, amount, places=9)
 
 
-class TestProductionFeeRatesV1:
+class TestProductionFeeRatesV1(unittest.TestCase):
     def _fee_v1(self, notional: float, bps: int) -> float:
         return notional * bps / 10000
 
     def test_sports_fees_v2_300bps(self):
-        assert self._fee_v1(100, 300) == pytest.approx(3.0, abs=1e-6)
+        self.assertAlmostEqual(self._fee_v1(100, 300), 3.0, delta=1e-6)
 
     def test_politics_tech_finance_mentions_400bps(self):
-        assert self._fee_v1(100, 400) == pytest.approx(4.0, abs=1e-6)
+        self.assertAlmostEqual(self._fee_v1(100, 400), 4.0, delta=1e-6)
 
     def test_culture_weather_general_economics_500bps(self):
-        assert self._fee_v1(100, 500) == pytest.approx(5.0, abs=1e-6)
+        self.assertAlmostEqual(self._fee_v1(100, 500), 5.0, delta=1e-6)
 
     def test_crypto_fees_v2_720bps(self):
-        assert self._fee_v1(100, 720) == pytest.approx(7.2, abs=1e-6)
+        self.assertAlmostEqual(self._fee_v1(100, 720), 7.2, delta=1e-6)
 
 
-class TestProductionFeeRatesV2:
+class TestProductionFeeRatesV2(unittest.TestCase):
     amount = 100
 
     def test_sports_v2_rate_0_03_exp_1_price_0_5(self):
-        assert calculate_platform_fee(self.amount, 0.5, 0.03, 1) == pytest.approx(1.5, abs=1e-6)
+        self.assertAlmostEqual(calculate_platform_fee(self.amount, 0.5, 0.03, 1), 1.5, delta=1e-6)
 
     def test_sports_v2_rate_0_03_exp_1_price_0_3(self):
-        assert calculate_platform_fee(self.amount, 0.3, 0.03, 1) == pytest.approx(2.1, abs=1e-6)
+        self.assertAlmostEqual(calculate_platform_fee(self.amount, 0.3, 0.03, 1), 2.1, delta=1e-6)
 
     def test_sports_v2_rate_0_03_exp_1_price_0_7(self):
-        assert calculate_platform_fee(self.amount, 0.7, 0.03, 1) == pytest.approx(0.9, abs=1e-6)
+        self.assertAlmostEqual(calculate_platform_fee(self.amount, 0.7, 0.03, 1), 0.9, delta=1e-6)
 
     def test_politics_rate_0_04_exp_1_price_0_5(self):
-        assert calculate_platform_fee(self.amount, 0.5, 0.04, 1) == pytest.approx(2.0, abs=1e-6)
+        self.assertAlmostEqual(calculate_platform_fee(self.amount, 0.5, 0.04, 1), 2.0, delta=1e-6)
 
     def test_politics_rate_0_04_exp_1_price_0_3(self):
-        assert calculate_platform_fee(self.amount, 0.3, 0.04, 1) == pytest.approx(2.8, abs=1e-6)
+        self.assertAlmostEqual(calculate_platform_fee(self.amount, 0.3, 0.04, 1), 2.8, delta=1e-6)
 
     def test_politics_rate_0_04_exp_1_price_0_7(self):
-        assert calculate_platform_fee(self.amount, 0.7, 0.04, 1) == pytest.approx(1.2, abs=1e-6)
+        self.assertAlmostEqual(calculate_platform_fee(self.amount, 0.7, 0.04, 1), 1.2, delta=1e-6)
 
     def test_culture_rate_0_05_exp_1_price_0_5(self):
-        assert calculate_platform_fee(self.amount, 0.5, 0.05, 1) == pytest.approx(2.5, abs=1e-6)
+        self.assertAlmostEqual(calculate_platform_fee(self.amount, 0.5, 0.05, 1), 2.5, delta=1e-6)
 
     def test_culture_rate_0_05_exp_1_price_0_3(self):
-        assert calculate_platform_fee(self.amount, 0.3, 0.05, 1) == pytest.approx(3.5, abs=1e-6)
+        self.assertAlmostEqual(calculate_platform_fee(self.amount, 0.3, 0.05, 1), 3.5, delta=1e-6)
 
     def test_culture_rate_0_05_exp_1_price_0_7(self):
-        assert calculate_platform_fee(self.amount, 0.7, 0.05, 1) == pytest.approx(1.5, abs=1e-6)
+        self.assertAlmostEqual(calculate_platform_fee(self.amount, 0.7, 0.05, 1), 1.5, delta=1e-6)
 
     def test_crypto_rate_0_072_exp_1_price_0_5(self):
-        assert calculate_platform_fee(self.amount, 0.5, 0.072, 1) == pytest.approx(3.6, abs=1e-6)
+        self.assertAlmostEqual(calculate_platform_fee(self.amount, 0.5, 0.072, 1), 3.6, delta=1e-6)
 
     def test_crypto_rate_0_072_exp_1_price_0_3(self):
-        assert calculate_platform_fee(self.amount, 0.3, 0.072, 1) == pytest.approx(5.04, abs=1e-6)
+        self.assertAlmostEqual(calculate_platform_fee(self.amount, 0.3, 0.072, 1), 5.04, delta=1e-6)
 
     def test_crypto_rate_0_072_exp_1_price_0_7(self):
-        assert calculate_platform_fee(self.amount, 0.7, 0.072, 1) == pytest.approx(2.16, abs=1e-6)
+        self.assertAlmostEqual(calculate_platform_fee(self.amount, 0.7, 0.072, 1), 2.16, delta=1e-6)
 
-    @pytest.mark.parametrize("rate,exponent,price", [
-        (0.03, 1, 0.3), (0.03, 1, 0.5), (0.03, 1, 0.7),
-        (0.04, 1, 0.3), (0.04, 1, 0.5), (0.04, 1, 0.7),
-        (0.05, 1, 0.3), (0.05, 1, 0.5), (0.05, 1, 0.7),
-        (0.072, 1, 0.3), (0.072, 1, 0.5), (0.072, 1, 0.7),
-    ])
-    def test_balance_equals_amount_adjusted_plus_fee_equals_balance(self, rate, exponent, price):
-        amount = 100
-        adjusted = adjust_market_buy_amount(amount, amount, price, rate, exponent, 0)
-        fee = calculate_platform_fee(adjusted, price, rate, exponent)
-        assert adjusted + fee == pytest.approx(amount, rel=1e-10)
+    def test_balance_adjusted_plus_fee_equals_amount_all_rates(self):
+        cases = [
+            (0.03, 1, 0.3), (0.03, 1, 0.5), (0.03, 1, 0.7),
+            (0.04, 1, 0.3), (0.04, 1, 0.5), (0.04, 1, 0.7),
+            (0.05, 1, 0.3), (0.05, 1, 0.5), (0.05, 1, 0.7),
+            (0.072, 1, 0.3), (0.072, 1, 0.5), (0.072, 1, 0.7),
+        ]
+        for rate, exponent, price in cases:
+            with self.subTest(rate=rate, exponent=exponent, price=price):
+                amount = 100
+                adjusted = adjust_market_buy_amount(amount, amount, price, rate, exponent, 0)
+                fee = calculate_platform_fee(adjusted, price, rate, exponent)
+                self.assertAlmostEqual(adjusted + fee, amount, places=9)

--- a/tests/test_fee_calculations.py
+++ b/tests/test_fee_calculations.py
@@ -156,23 +156,6 @@ class TestAdjustBuyAmountForFees(unittest.TestCase):
         self.assertAlmostEqual(adjusted + platform_fee + builder_fee, amount, places=9)
 
 
-class TestProductionFeeRatesV1(unittest.TestCase):
-    def _fee_v1(self, notional: float, bps: int) -> float:
-        return notional * bps / 10000
-
-    def test_sports_fees_v2_300bps(self):
-        self.assertAlmostEqual(self._fee_v1(100, 300), 3.0, delta=1e-6)
-
-    def test_politics_tech_finance_mentions_400bps(self):
-        self.assertAlmostEqual(self._fee_v1(100, 400), 4.0, delta=1e-6)
-
-    def test_culture_weather_general_economics_500bps(self):
-        self.assertAlmostEqual(self._fee_v1(100, 500), 5.0, delta=1e-6)
-
-    def test_crypto_fees_v2_720bps(self):
-        self.assertAlmostEqual(self._fee_v1(100, 720), 7.2, delta=1e-6)
-
-
 class TestProductionFeeRatesV2(unittest.TestCase):
     amount = 100
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches order creation/signing for legacy `version=1` orders and changes how fee rates are fetched/cached, which could impact order validity or fee parameters sent to the API. Changes are localized and covered by expanded unit tests, keeping overall risk moderate.
> 
> **Overview**
> Fixes legacy *V1 order fee handling* by introducing a dedicated `__fee_rates` cache for `GET_FEE_RATE` (`base_fee` in bps) and wiring that value through `ClobClient.create_order`/`create_market_order` into `OrderBuilder` for `version=1` orders, with validation to reject user-provided fee bps that don’t match the market.
> 
> Also relaxes order creation to auto-resolve `tick_size` from market data (instead of requiring it in options), switches various signed request payload serializations to `json.dumps(..., ensure_ascii=False)`, and tightens typing/formatting plus adds/updates unit tests (including new fee-calculation tests and V1/V2 signed-order assertions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e943793a7cabf1f6d4553a3ecb5edb68c58fafb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->