### PR TITLE
version: 1.0.0

### DIFF
--- a/py_clob_client_v2/client.py
+++ b/py_clob_client_v2/client.py
@@ -747,7 +747,7 @@ class ClobClient:
 
         builder_code = getattr(order_args, "builder_code", BYTES32_ZERO)
 
-        if (order_args.side == "BUY" or order_args.side == Side.BUY) and order_args.user_usdc_balance:
+        if (order_args.side == "BUY" or order_args.side == Side.BUY) and getattr(order_args, "user_usdc_balance", None):
             self.__ensure_builder_fee_rate_cached(builder_code)
             builder_taker_fee_rate = (
                 self.__builder_fee_rates[builder_code].taker

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="py_clob_client_v2",
-    version="0.0.4",
+    version="1.0.0",
     author="Polymarket Engineering",
     author_email="engineering@polymarket.com",
     maintainer="Polymarket Engineering",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: a packaging version bump plus a small defensive check in `create_market_order` that should only prevent runtime errors when `user_usdc_balance` is absent.
> 
> **Overview**
> Updates the published package version to **`1.0.0`**.
> 
> Tightens `create_market_order`’s BUY-side logic to only run the `adjust_market_buy_amount` path when `user_usdc_balance` is actually provided (via `getattr(...)`), avoiding failures when that field is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f8aa864523952a2da9fb73c5d2d630dd7e52ca8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->