### PR TITLE
fix: preserve 0 values for trade before/after filters

### DIFF
--- a/py_clob_client_v2/client.py
+++ b/py_clob_client_v2/client.py
@@ -560,9 +560,9 @@ class ClobClient:
                     p["market"] = params.market
                 if params.asset_id:
                     p["asset_id"] = params.asset_id
-                if params.after:
+                if params.after is not None:
                     p["after"] = params.after
-                if params.before:
+                if params.before is not None:
                     p["before"] = params.before
                 if params.maker_address:
                     p["maker_address"] = params.maker_address
@@ -587,9 +587,9 @@ class ClobClient:
                 p["market"] = params.market
             if params.asset_id:
                 p["asset_id"] = params.asset_id
-            if params.after:
+            if params.after is not None:
                 p["after"] = params.after
-            if params.before:
+            if params.before is not None:
                 p["before"] = params.before
             if params.maker_address:
                 p["maker_address"] = params.maker_address
@@ -623,9 +623,9 @@ class ClobClient:
             p["market"] = params.market
         if params.asset_id:
             p["asset_id"] = params.asset_id
-        if params.before:
+        if params.before is not None:
             p["before"] = params.before
-        if params.after:
+        if params.after is not None:
             p["after"] = params.after
         p["next_cursor"] = cursor
         response = self._get(f"{self.host}{GET_BUILDER_TRADES}", headers=headers, params=p)


### PR DESCRIPTION
## Summary
- `get_trades`, `get_trades_paginated`, and `get_builder_trades` use `if params.after:` / `if params.before:` to decide whether to include the filter. Because `0` is falsy in Python, a legitimate 0 (e.g. epoch 0 or any intentional boundary value) is silently stripped.
- Switch to `is not None` so only an unset filter is skipped. Other string params (`market`, `asset_id`, `id`, `maker_address`) are unchanged since for them empty/None both mean "unset".

## Test plan
- [ ] Call `get_trades(TradeParams(after=0))` and verify `after=0` is now passed as a query parameter.
- [ ] Existing behavior for `after=None` / `before=None` is unchanged (still omitted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to query parameter construction for trade endpoints; main risk is subtle behavior change for callers who previously relied on `0` being omitted.
> 
> **Overview**
> Fixes trade-query filtering so `after`/`before` values of `0` are no longer dropped as falsy. In `get_trades`, `get_trades_paginated`, and `get_builder_trades`, the client now includes these parameters whenever they are explicitly set (checking `is not None`) while preserving existing behavior for unset (`None`) filters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 092d62d9f3b3b1acb36e721be3d5326f54d09792. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->