### PR TITLE
fix: narrow create_or_derive_api_key fallback to 4xx errors

### DIFF
--- a/py_clob_client_v2/client.py
+++ b/py_clob_client_v2/client.py
@@ -103,7 +103,7 @@ from .endpoints import (
     UPDATE_BALANCE_ALLOWANCE,
     VERSION,
 )
-from .exceptions import PolyException
+from .exceptions import PolyApiException, PolyException
 from .headers.headers import create_level_1_headers, create_level_2_headers
 from .http_helpers.helpers import (
     delete,
@@ -478,8 +478,13 @@ class ClobClient:
             resp = self.create_api_key(nonce=nonce)
             if resp.api_key:
                 return resp
-        except Exception:
-            pass
+        except PolyApiException as exc:
+            # Only fall through to derive on client errors (e.g. "key already
+            # exists"). 5xx / network errors should propagate so the caller
+            # learns the upstream is unhealthy instead of silently deriving.
+            status = exc.status_code
+            if status is None or not (400 <= status < 500):
+                raise
         return self.derive_api_key(nonce=nonce)
 
     def get_api_keys(self):

--- a/py_clob_client_v2/client.py
+++ b/py_clob_client_v2/client.py
@@ -473,17 +473,21 @@ class ClobClient:
             api_passphrase=resp["passphrase"],
         )
 
+    # Status codes from create_api_key that mean "a key already exists,
+    # derive instead". Conservatively narrow: 409 Conflict is the idiomatic
+    # shape, 400 covers servers that overload it for the same condition.
+    # 401/403/429/5xx/network errors are NOT in this set — they propagate
+    # so the caller can handle auth, rate-limit, or upstream failures
+    # instead of silently receiving a derived key they did not ask for.
+    _CREATE_API_KEY_DERIVE_FALLBACK_STATUSES = frozenset({400, 409})
+
     def create_or_derive_api_key(self, nonce: int = None) -> ApiCreds:
         try:
             resp = self.create_api_key(nonce=nonce)
             if resp.api_key:
                 return resp
         except PolyApiException as exc:
-            # Only fall through to derive on client errors (e.g. "key already
-            # exists"). 5xx / network errors should propagate so the caller
-            # learns the upstream is unhealthy instead of silently deriving.
-            status = exc.status_code
-            if status is None or not (400 <= status < 500):
+            if exc.status_code not in self._CREATE_API_KEY_DERIVE_FALLBACK_STATUSES:
                 raise
         return self.derive_api_key(nonce=nonce)
 


### PR DESCRIPTION
## Summary
- `create_or_derive_api_key` swallows **every** exception from `create_api_key` and silently falls through to `derive_api_key`. A 5xx, a timeout, or any other transient/unexpected error is indistinguishable from the intended "key already exists" case, and the caller ends up bound to a *derived* key they did not expect.
- Narrow the catch to `PolyApiException` with a 4xx status (the real "already exists" shape). 5xx, network errors, and unexpected exceptions now propagate so the caller can handle them.

## Test plan
- [ ] Patch `create_api_key` to raise `PolyApiException` with status=400 → fallback to `derive_api_key` still happens.
- [ ] Patch `create_api_key` to raise `PolyApiException` with status=500 → exception propagates.
- [ ] Patch `create_api_key` to raise a network-level `PolyApiException` (status=None) → exception propagates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to exception handling around API key creation; main risk is behavior change for callers who previously relied on silent fallback on transient errors.
> 
> **Overview**
> Tightens `ClobClient.create_or_derive_api_key` error handling so it only falls back to `derive_api_key` when `create_api_key` fails with a `PolyApiException` having status `400` or `409` (interpreted as “key already exists”).
> 
> All other failures (auth/rate-limit/server errors, network exceptions, or unexpected exceptions) now propagate instead of being silently swallowed, reducing the chance of returning a derived key on transient or unrelated errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c38f44874a0ac05d2c1dcd8b56b3a3b7f566e566. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->