### PR TITLE
fix: use cryptographic RNG for order salt

### DIFF
--- a/py_clob_client_v2/order_utils/utils.py
+++ b/py_clob_client_v2/order_utils/utils.py
@@ -1,6 +1,10 @@
-import random
-import time
+import secrets
 
 
 def generate_order_salt() -> str:
-    return str(int(random.random() * (time.time_ns() // 1_000_000)))
+    # 64 bits of entropy from a cryptographically strong RNG. The previous
+    # implementation used `random.random() * current_ms_time`, which:
+    #   - is not cryptographically secure
+    #   - always yields a value strictly less than `current_ms_time`
+    #   - has a realistic collision rate under concurrent order creation
+    return str(secrets.randbits(64))


### PR DESCRIPTION
## Summary
- `generate_order_salt` was `int(random.random() * current_ms_time)`:
  - `random.random()` is not cryptographic.
  - The result is always strictly less than `current_ms_time`, so the salt is not uniformly distributed.
  - Concurrent order creation in the same millisecond can produce duplicate salts, which the exchange rejects as duplicate orders.
- Switch to `secrets.randbits(64)` — 64 bits of uniform cryptographic entropy, well within the `uint256` salt field.

## Test plan
- [ ] Generate a few thousand salts back-to-back and confirm no duplicates.
- [ ] End-to-end order placement still succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to salt generation; low risk aside from potential downstream assumptions about salt format/range.
> 
> **Overview**
> `generate_order_salt` now uses `secrets.randbits(64)` instead of a `random.random() * time`-based value, improving entropy, uniformity, and reducing collision risk during concurrent order creation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 275f951ab1da02fac58c67f4b2e90fa8310abadb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->