### PR TITLE
fix: preserve explicit fee_rate_bps=0 intent

### DIFF
--- a/py_clob_client_v2/client.py
+++ b/py_clob_client_v2/client.py
@@ -703,7 +703,7 @@ class ClobClient:
         )
         version = self.__resolve_version()
 
-        user_fee_rate_bps = getattr(order_args, "fee_rate_bps", None) or None
+        user_fee_rate_bps = getattr(order_args, "fee_rate_bps", None)
         fee_rate_bps = self.__resolve_fee_rate_bps(token_id, user_fee_rate_bps) if version == 1 else None
 
         return self.builder.build_order(
@@ -771,7 +771,7 @@ class ClobClient:
         )
         version = self.__resolve_version()
 
-        user_fee_rate_bps = getattr(order_args, "fee_rate_bps", None) or None
+        user_fee_rate_bps = getattr(order_args, "fee_rate_bps", None)
         fee_rate_bps = self.__resolve_fee_rate_bps(token_id, user_fee_rate_bps) if version == 1 else None
 
         return self.builder.build_market_order(

--- a/py_clob_client_v2/clob_types.py
+++ b/py_clob_client_v2/clob_types.py
@@ -58,8 +58,10 @@ class OrderArgsV1:
     expiration: int = 0
     """Timestamp after which the order is expired"""
 
-    fee_rate_bps: int = 0
-    """Fee rate in basis points charged to the order maker"""
+    fee_rate_bps: Optional[int] = None
+    """Fee rate in basis points charged to the order maker. None = use the
+    market's configured fee rate. 0 explicitly requests a zero fee rate and
+    will error if it disagrees with the market."""
 
     nonce: int = 0
     """Nonce used for onchain cancellations"""
@@ -119,8 +121,10 @@ class MarketOrderArgsV1:
 
     order_type: OrderType = OrderType.FOK
 
-    fee_rate_bps: int = 0
-    """Fee rate in basis points charged to the order maker"""
+    fee_rate_bps: Optional[int] = None
+    """Fee rate in basis points charged to the order maker. None = use the
+    market's configured fee rate. 0 explicitly requests a zero fee rate and
+    will error if it disagrees with the market."""
 
     nonce: int = 0
     """Nonce used for onchain cancellations"""

--- a/py_clob_client_v2/order_builder/builder.py
+++ b/py_clob_client_v2/order_builder/builder.py
@@ -155,7 +155,7 @@ class OrderBuilder:
             )
             resolved_fee_rate_bps = (
                 fee_rate_bps if fee_rate_bps is not None
-                else getattr(order_args, "fee_rate_bps", 0)
+                else (getattr(order_args, "fee_rate_bps", None) or 0)
             )
             order_data = OrderDataV1(
                 maker=self.funder,
@@ -236,7 +236,7 @@ class OrderBuilder:
             )
             resolved_fee_rate_bps = (
                 fee_rate_bps if fee_rate_bps is not None
-                else getattr(order_args, "fee_rate_bps", 0)
+                else (getattr(order_args, "fee_rate_bps", None) or 0)
             )
             order_data = OrderDataV1(
                 maker=self.funder,


### PR DESCRIPTION
## Summary
- `create_order` / `create_market_order` ran `getattr(order_args, \"fee_rate_bps\", None) or None`, which collapses a user-supplied `fee_rate_bps=0` into `None`. `__resolve_fee_rate_bps` then skipped its mismatch guard and silently returned the market's fee rate. A caller asking for zero fees was silently charged the market rate.
- Root cause: `OrderArgsV1.fee_rate_bps` (and `MarketOrderArgsV1`) defaulted to `0`, so the client had no way to distinguish "unset" from "explicit 0".

## Fix
- Change V1 `fee_rate_bps` default to `Optional[int] = None`. Now:
  - `None`  → use market fee rate (previous default behavior; unchanged)
  - `0`     → explicit zero; raises if market rate is non-zero
  - `N`     → explicit; raises if `N != market rate`
- Drop the `or None` in the client — `None` now flows through naturally.
- `OrderBuilder` already falls back to `0` if fee_rate_bps is None, so on-chain orders still carry a numeric string.

## Test plan
- [ ] V1 order with no `fee_rate_bps` → market rate used (unchanged).
- [ ] V1 order with `fee_rate_bps=0` and market rate > 0 → `PolyException` raised (was: silently used market rate).
- [ ] V1 order with `fee_rate_bps=N` matching market → N used.
- [ ] V1 order with `fee_rate_bps=N` not matching market → `PolyException`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes fee-rate semantics for V1 order creation and can cause new validation errors (e.g., explicit `0` now triggering mismatch checks) affecting order submission behavior.
> 
> **Overview**
> Fixes V1 order fee handling so an explicitly provided `fee_rate_bps=0` is no longer treated as “unset”.
> 
> `OrderArgsV1`/`MarketOrderArgsV1` now default `fee_rate_bps` to `None` (meaning “use market fee”), `create_order`/`create_market_order` stop collapsing falsy values to `None`, and the V1 `OrderBuilder` continues to serialize a numeric `feeRateBps` by defaulting `None` to `0` when building on-chain order data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e85c88d044536e15070536a7fc35575250c123af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->