### PR TITLE
fix: sort-agnostic orderbook walk for market price calculation

### DIFF
--- a/py_clob_client_v2/order_builder/builder.py
+++ b/py_clob_client_v2/order_builder/builder.py
@@ -40,6 +40,14 @@ ROUNDING_CONFIG: dict = {
     "0.0001": RoundConfig(price=4, size=2, amount=6),
 }
 
+
+def _normalize_positions(positions: list):
+    """Yield (size, price) float pairs, accepting dicts or OrderSummary-like objects."""
+    for p in positions:
+        size = p["size"] if isinstance(p, dict) else p.size
+        price = p["price"] if isinstance(p, dict) else p.price
+        yield float(size), float(price)
+
 class OrderBuilder:
     def __init__(
         self,
@@ -291,19 +299,22 @@ class OrderBuilder:
         if not positions:
             raise Exception("no match")
 
-        total = 0
-        for p in reversed(positions):
-            size = p["size"] if isinstance(p, dict) else p.size
-            price = p["price"] if isinstance(p, dict) else p.price
-            total += float(size) * float(price)
+        # Walk asks from cheapest to most expensive so the returned price is
+        # the marginal price required to fill `amount_to_match`. Sort locally
+        # to avoid depending on the server's (undocumented) ordering.
+        walk = sorted(_normalize_positions(positions), key=lambda x: x[1])
+
+        total = 0.0
+        for size, price in walk:
+            total += size * price
             if total >= amount_to_match:
-                return float(price)
+                return price
 
         if order_type == OrderType.FOK:
             raise Exception("no match")
 
-        p0 = positions[0]
-        return float(p0["price"] if isinstance(p0, dict) else p0.price)
+        # Book can't fully fill — return the worst (highest) price walked.
+        return walk[-1][1]
 
     def calculate_sell_market_price(
         self,
@@ -314,16 +325,19 @@ class OrderBuilder:
         if not positions:
             raise Exception("no match")
 
-        total = 0
-        for p in reversed(positions):
-            size = p["size"] if isinstance(p, dict) else p.size
-            price = p["price"] if isinstance(p, dict) else p.price
-            total += float(size)
+        # Walk bids from highest to lowest so the returned price is the
+        # marginal price the seller must accept to move `amount_to_match`
+        # shares. Sort locally to avoid depending on server ordering.
+        walk = sorted(_normalize_positions(positions), key=lambda x: x[1], reverse=True)
+
+        total = 0.0
+        for size, price in walk:
+            total += size
             if total >= amount_to_match:
-                return float(price)
+                return price
 
         if order_type == OrderType.FOK:
             raise Exception("no match")
 
-        p0 = positions[0]
-        return float(p0["price"] if isinstance(p0, dict) else p0.price)
+        # Book can't fully fill — return the worst (lowest) price walked.
+        return walk[-1][1]


### PR DESCRIPTION
## Summary
- `calculate_buy_market_price` / `calculate_sell_market_price` iterated `reversed(positions)`, assuming the server returns **asks descending** and **bids ascending**. That's an undocumented contract. If the server ever changes ordering (or a caller passes a pre-sorted snapshot), the walk returns the *worst* price rather than the marginal price required to fill the amount.
- Sort locally instead:
  - buys walk asks ascending (cheapest first)
  - sells walk bids descending (highest first)
- Added a `_normalize_positions` helper to consolidate the dict-vs-dataclass access.

## Test plan
- [ ] BUY walk returns the same marginal price for ascending and descending ask inputs.
- [ ] SELL walk returns the same marginal price for ascending and descending bid inputs.
- [ ] FOK with insufficient book still raises.
- [ ] FAK with insufficient book returns the worst price walked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core market-price calculation used for building market orders, which can alter execution price selection and edge-case behavior when books are partially fillable.
> 
> **Overview**
> Fixes market price estimation to be **independent of server/orderbook input ordering**.
> 
> `calculate_buy_market_price` and `calculate_sell_market_price` now normalize position entries (dict vs object), locally sort by price (asks ascending, bids descending), and return the *marginal* price needed to fill `amount_to_match`; for non-`FOK` orders with insufficient depth, they return the worst price reached during the walk instead of relying on the first entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c81a12a78f49a5e8ff1d175434fc3632a37271b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->