### PR TITLE
refactor: keep adjust_market_buy_amount in Decimal for integer exponents

### DIFF
--- a/py_clob_client_v2/utilities.py
+++ b/py_clob_client_v2/utilities.py
@@ -63,8 +63,16 @@ def adjust_market_buy_amount(
     d_fee_rate = Decimal(str(fee_rate))
     d_fee_exponent = Decimal(str(fee_exponent))
     d_btr = Decimal(str(builder_taker_fee_rate))
-    base = float(d_price * (Decimal("1") - d_price))
-    d_pfr = d_fee_rate * Decimal(str(base ** float(d_fee_exponent)))
+
+    base = d_price * (Decimal("1") - d_price)
+    # Production fee exponents are integer (e.g. 1 or 2). Keep the whole
+    # calculation in Decimal when possible; only fall back to a float pow
+    # for the (unusual) non-integer case.
+    if d_fee_exponent == d_fee_exponent.to_integral_value():
+        base_pow = base ** int(d_fee_exponent)
+    else:
+        base_pow = Decimal(str(float(base) ** float(d_fee_exponent)))
+    d_pfr = d_fee_rate * base_pow
 
     platform_fee = d_amount / d_price * d_pfr
     total_cost = d_amount + platform_fee + d_amount * d_btr


### PR DESCRIPTION
## Summary
- `adjust_market_buy_amount` converts `d_price * (1 - d_price)` to `float`, raises it to the fee exponent in float, then round-trips back through `str()` → `Decimal`. On today's production exponents (1 or 2) the output is numerically identical, so this is a **refactor**, not a bug fix — but the code was advertising Decimal precision it then silently threw away.
- When the exponent is integer-valued (the common case), stay in Decimal for the power. Non-integer exponents still fall back to the float round-trip.

## Test plan
- [ ] Existing fee-calculation tests (`tests/test_fee_calculations.py`) still pass.
- [ ] `adjust_market_buy_amount` numerical output is unchanged on the production cases (rate/exp/price matrix in `TestProductionFeeRatesV2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized refactor in fee math intended to preserve precision; behavior should remain the same for production integer exponents, with only edge-case risk for non-integer exponents.
> 
> **Overview**
> Refactors `adjust_market_buy_amount` fee calculation to avoid converting `price * (1 - price)` to `float` for the common case where `fee_exponent` is integer-valued.
> 
> The power (`base ** fee_exponent`) is now computed in `Decimal` when the exponent is integral, with a float `pow` round-trip retained only for non-integer exponents; downstream fee/total-cost logic is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41940117e35218335d0d2d0e1dd13a3f91f78719. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->