### PR TITLE
fix: only retry post_order on explicit version mismatch

### DIFF
--- a/py_clob_client_v2/client.py
+++ b/py_clob_client_v2/client.py
@@ -1080,10 +1080,16 @@ class ClobClient:
         return ORDER_VERSION_MISMATCH_ERROR in message
 
     def _retry_on_version_update(self, func):
-        version = self.__resolve_version()
-        result = None
-        for _ in range(2):
+        # Retry once iff the first response explicitly reports a version
+        # mismatch. `post_order` already force-updates the cached version
+        # when it detects the mismatch, so the retry just rebuilds the
+        # order against the new version and re-posts.
+        #
+        # Previously the retry decision compared the cached version before
+        # and after `func()`, which also fires if anything else (another
+        # call, another thread) invalidates the cache mid-flight. In that
+        # case a successful order could be silently re-posted.
+        result = func()
+        if self._is_order_version_mismatch(result):
             result = func()
-            if version == self.__resolve_version():
-                break
         return result


### PR DESCRIPTION
## Summary
- `_retry_on_version_update` compared the cached version before and after `func()` to decide whether to retry:
  ```python
  version = self.__resolve_version()
  for _ in range(2):
      result = func()
      if version == self.__resolve_version():
          break
  ```
- That works *if* the only thing that changes the cached version is `post_order` detecting a version mismatch. But **any** other code path that invalidates the version cache between the two reads (another concurrent call, an explicit `force_update=True`) will make the two values diverge — and a successful order gets silently re-posted.
- Make the retry trigger explicit: only retry iff the first response is itself a version-mismatch error (`_is_order_version_mismatch(result)`). `post_order` already force-updates the cached version when it sees the mismatch, so the retry rebuilds the order against the new version correctly.

## Test plan
- [ ] First post returns success → no retry.
- [ ] First post returns a version-mismatch error → exactly one retry (new version cached, order rebuilt).
- [ ] First post returns any other error → no retry.
- [ ] Cache invalidated by an unrelated code path → no spurious retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes order-submission retry semantics, which can affect live trading behavior (e.g., fewer duplicate posts but potentially fewer automatic retries in edge cases). Scope is small and localized to the version-mismatch retry path.
> 
> **Overview**
> Tightens `create_and_post_order`/`create_and_post_market_order` retry behavior by changing `_retry_on_version_update` to **retry exactly once only when the first response contains an explicit order-version-mismatch error**, rather than retrying whenever the cached version changes during the call.
> 
> This prevents a successful order from being silently re-posted if the version cache is invalidated by unrelated concurrent activity, while still allowing `post_order` to refresh the cached version and rebuild/repost on true mismatches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6be5755e3c1ba769628b647b3e1253998dd401f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->