### PR TITLE
fix: use eth-account's public unsafe_sign_hash API

### DIFF
--- a/py_clob_client_v2/signer.py
+++ b/py_clob_client_v2/signer.py
@@ -16,7 +16,11 @@ class Signer:
         return self.chain_id
 
     def sign(self, message_hash):
-        """
-        Signs a message hash
-        """
-        return Account._sign_hash(message_hash, self.private_key).signature.hex()
+        """Sign a 32-byte message hash and return a hex signature (no 0x prefix)."""
+        # `Account.unsafe_sign_hash` is the public successor to the private
+        # `Account._sign_hash`. Fall back to the legacy names on older
+        # eth-account releases.
+        signer = getattr(Account, "unsafe_sign_hash", None) or getattr(
+            Account, "_sign_hash", None
+        ) or getattr(Account, "signHash")
+        return signer(message_hash, self.private_key).signature.hex()


### PR DESCRIPTION
## Summary
- `Signer.sign` called the private `Account._sign_hash`. Upstream renamed it to `Account.unsafe_sign_hash`, and `_sign_hash` has been removed in recent eth-account releases. `setup.py` pins only `eth-account>=0.13.0` with no upper bound — a fresh install can now raise `AttributeError: _sign_hash` on every L1-auth header creation (`create_api_key`, `derive_api_key`, anything going through `sign_clob_auth_message`).
- Switch to the public `Account.unsafe_sign_hash`. Kept a runtime fallback to the legacy names so the SDK still works on older eth-account pins.

## Test plan
- [ ] `create_api_key` / `derive_api_key` succeed on the currently pinned eth-account version.
- [ ] Same on an eth-account where `_sign_hash` has been removed (latest releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches signature generation used for authentication; while intended to be compatible, any behavioral difference in hash signing or parameter types could break request auth across eth-account versions.
> 
> **Overview**
> Updates `Signer.sign` to stop calling the private `Account._sign_hash` and instead prefer the public `Account.unsafe_sign_hash`, improving compatibility with newer `eth-account` releases.
> 
> Adds a runtime fallback to legacy signing APIs (`_sign_hash` / `signHash`) so the client can still sign across a wider range of `eth-account` versions, and clarifies the method contract/docstring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0a8240f1072b97347db8c65bea7d3bdd0e7786c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->