### PR TITLE
Custom signer

### DIFF
--- a/py_clob_client_v2/client.py
+++ b/py_clob_client_v2/client.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Optional
+from typing import Optional, Callable
 
 from .clob_types import (
     ApiCreds,
@@ -143,6 +143,8 @@ class ClobClient:
         builder_config: BuilderConfig = None,
         use_server_time: bool = False,
         retry_on_error: bool = False,
+        address_override: str = None,
+        sign_callback_override: Optional[Callable] = None,
     ):
         self.host = host.rstrip("/")
         self.chain_id = chain_id
@@ -150,7 +152,15 @@ class ClobClient:
         self.retry_on_error = retry_on_error
         self.builder_config = builder_config
 
-        self.signer = Signer(key, chain_id) if key else None
+        self.signer = None
+        if sign_callback_override is not None:
+            self.signer = Signer(
+                chain_id=chain_id,
+                address_override=address_override,
+                sign_callback_override=sign_callback_override,
+            )
+        elif key:
+            self.signer = Signer(private_key=key, chain_id=chain_id)
         self.creds = creds
         self.mode = self._get_client_mode()
 
@@ -219,9 +229,9 @@ class ClobClient:
             return result.get("time") or result.get("timestamp")
         return int(result)
 
-    def _l1_headers(self, nonce: int = None) -> dict:
+    async def _l1_headers(self, nonce: int = None) -> dict:
         self.assert_level_1_auth()
-        return create_level_1_headers(
+        return await create_level_1_headers(
             self.signer, nonce=nonce, timestamp=self._get_timestamp()
         )
 
@@ -455,8 +465,8 @@ class ClobClient:
             results.extend(response["data"])
         return results
 
-    def create_api_key(self, nonce: int = None) -> ApiCreds:
-        headers = self._l1_headers(nonce=nonce)
+    async def create_api_key(self, nonce: int = None) -> ApiCreds:
+        headers = await self._l1_headers(nonce=nonce)
         resp = self._post(f"{self.host}{CREATE_API_KEY}", headers=headers)
         return ApiCreds(
             api_key=resp["apiKey"],
@@ -464,8 +474,8 @@ class ClobClient:
             api_passphrase=resp["passphrase"],
         )
 
-    def derive_api_key(self, nonce: int = None) -> ApiCreds:
-        headers = self._l1_headers(nonce=nonce)
+    async def derive_api_key(self, nonce: int = None) -> ApiCreds:
+        headers = await self._l1_headers(nonce=nonce)
         resp = self._get(f"{self.host}{DERIVE_API_KEY}", headers=headers)
         return ApiCreds(
             api_key=resp["apiKey"],
@@ -473,14 +483,17 @@ class ClobClient:
             api_passphrase=resp["passphrase"],
         )
 
-    def create_or_derive_api_key(self, nonce: int = None) -> ApiCreds:
+    async def create_or_derive_api_key(self, nonce: int = None) -> ApiCreds:
         try:
-            resp = self.create_api_key(nonce=nonce)
+            resp = await self.create_api_key(nonce=nonce)
             if resp.api_key:
                 return resp
         except Exception:
             pass
-        return self.derive_api_key(nonce=nonce)
+        return await self.derive_api_key(nonce=nonce)
+
+    async def create_or_derive_api_creds(self, nonce: int = None) -> ApiCreds:
+        return await self.create_or_derive_api_key(nonce=nonce)
 
     def get_api_keys(self):
         headers = self._l2_headers("GET", GET_API_KEYS)
@@ -673,7 +686,7 @@ class ClobClient:
                 p["token_id"] = params.token_id
         return self._get(f"{self.host}{UPDATE_BALANCE_ALLOWANCE}", headers=headers, params=p)
 
-    def create_order(
+    async def create_order(
         self,
         order_args: OrderArgsV2,
         options: PartialCreateOrderOptions = None,
@@ -706,14 +719,14 @@ class ClobClient:
         user_fee_rate_bps = getattr(order_args, "fee_rate_bps", None) or None
         fee_rate_bps = self.__resolve_fee_rate_bps(token_id, user_fee_rate_bps) if version == 1 else None
 
-        return self.builder.build_order(
+        return await self.builder.build_order(
             order_args,
             CreateOrderOptions(tick_size=tick_size, neg_risk=neg_risk),
             version=version,
             fee_rate_bps=fee_rate_bps,
         )
 
-    def create_market_order(
+    async def create_market_order(
         self,
         order_args: MarketOrderArgsV2,
         options: PartialCreateOrderOptions = None,
@@ -774,14 +787,14 @@ class ClobClient:
         user_fee_rate_bps = getattr(order_args, "fee_rate_bps", None) or None
         fee_rate_bps = self.__resolve_fee_rate_bps(token_id, user_fee_rate_bps) if version == 1 else None
 
-        return self.builder.build_market_order(
+        return await self.builder.build_market_order(
             order_args,
             CreateOrderOptions(tick_size=tick_size, neg_risk=neg_risk),
             version=version,
             fee_rate_bps=fee_rate_bps,
         )
 
-    def create_and_post_order(
+    async def create_and_post_order(
         self,
         order_args: OrderArgsV2,
         options: PartialCreateOrderOptions = None,
@@ -789,24 +802,24 @@ class ClobClient:
         post_only: bool = False,
         defer_exec: bool = False,
     ):
-        return self._retry_on_version_update(
-            lambda: self.post_order(
-                self.create_order(order_args, options), order_type, post_only, defer_exec
-            )
-        )
+        async def submit():
+            order = await self.create_order(order_args, options)
+            return self.post_order(order, order_type, post_only, defer_exec)
 
-    def create_and_post_market_order(
+        return await self._retry_on_version_update_async(submit)
+
+    async def create_and_post_market_order(
         self,
         order_args: MarketOrderArgsV2,
         options: PartialCreateOrderOptions = None,
         order_type: OrderType = OrderType.FOK,
         defer_exec: bool = False,
     ):
-        return self._retry_on_version_update(
-            lambda: self.post_order(
-                self.create_market_order(order_args, options), order_type, False, defer_exec
-            )
-        )
+        async def submit():
+            order = await self.create_market_order(order_args, options)
+            return self.post_order(order, order_type, False, defer_exec)
+
+        return await self._retry_on_version_update_async(submit)
 
     def post_order(
         self,
@@ -1084,6 +1097,15 @@ class ClobClient:
         result = None
         for _ in range(2):
             result = func()
+            if version == self.__resolve_version():
+                break
+        return result
+
+    async def _retry_on_version_update_async(self, func):
+        version = self.__resolve_version()
+        result = None
+        for _ in range(2):
+            result = await func()
             if version == self.__resolve_version():
                 break
         return result

--- a/py_clob_client_v2/headers/headers.py
+++ b/py_clob_client_v2/headers/headers.py
@@ -14,7 +14,7 @@ POLY_API_KEY = "POLY_API_KEY"
 POLY_PASSPHRASE = "POLY_PASSPHRASE"
 
 
-def create_level_1_headers(
+async def create_level_1_headers(
     signer: Signer, nonce: int = None, timestamp: Optional[int] = None
 ):
     """
@@ -24,7 +24,7 @@ def create_level_1_headers(
     ts = timestamp if timestamp is not None else int(datetime.now().timestamp())
     n = nonce if nonce is not None else 0
 
-    signature = sign_clob_auth_message(signer, ts, n)
+    signature = await sign_clob_auth_message(signer, ts, n)
     return {
         POLY_ADDRESS: signer.address(),
         POLY_SIGNATURE: signature,

--- a/py_clob_client_v2/order_builder/builder.py
+++ b/py_clob_client_v2/order_builder/builder.py
@@ -121,7 +121,7 @@ class OrderBuilder:
         else:
             raise ValueError(f"order_args.side must be '{BUY}' or '{SELL}'")
 
-    def build_order(
+    async def build_order(
         self,
         order_args: Union[OrderArgsV1, OrderArgsV2],
         options: CreateOrderOptions,
@@ -173,7 +173,7 @@ class OrderBuilder:
             builder = ExchangeOrderBuilderV1(
                 exchange_address, self.signer.get_chain_id(), self.signer
             )
-            return builder.build_signed_order(order_data)
+            return await builder.build_signed_order(order_data)
 
         elif version == 2:
             exchange_address = (
@@ -197,12 +197,12 @@ class OrderBuilder:
             builder = ExchangeOrderBuilderV2(
                 exchange_address, self.signer.get_chain_id(), self.signer
             )
-            return builder.build_signed_order(order_data)
+            return await builder.build_signed_order(order_data)
 
         else:
             raise ValueError(f"unsupported order version {version}")
 
-    def build_market_order(
+    async def build_market_order(
         self,
         order_args: Union[MarketOrderArgsV1, MarketOrderArgsV2],
         options: CreateOrderOptions,
@@ -254,7 +254,7 @@ class OrderBuilder:
             builder = ExchangeOrderBuilderV1(
                 exchange_address, self.signer.get_chain_id(), self.signer
             )
-            return builder.build_signed_order(order_data)
+            return await builder.build_signed_order(order_data)
 
         elif version == 2:
             exchange_address = (
@@ -277,7 +277,7 @@ class OrderBuilder:
             builder = ExchangeOrderBuilderV2(
                 exchange_address, self.signer.get_chain_id(), self.signer
             )
-            return builder.build_signed_order(order_data)
+            return await builder.build_signed_order(order_data)
 
         else:
             raise ValueError(f"unsupported order version {version}")

--- a/py_clob_client_v2/order_utils/exchange_order_builder_v1.py
+++ b/py_clob_client_v2/order_utils/exchange_order_builder_v1.py
@@ -1,7 +1,7 @@
 import dataclasses
-from eth_account import Account
 from eth_account.messages import encode_typed_data
 from eth_utils import keccak as _keccak
+from py_order_utils.utils import prepend_zx
 
 
 def _hash_message(msg) -> bytes:
@@ -33,10 +33,10 @@ class ExchangeOrderBuilderV1:
         self.signer = signer
         self.generate_salt = generate_salt
 
-    def build_signed_order(self, order_data: OrderDataV1) -> SignedOrderV1:
+    async def build_signed_order(self, order_data: OrderDataV1) -> SignedOrderV1:
         order = self.build_order(order_data)
         typed_data = self.build_order_typed_data(order)
-        signature = self.build_order_signature(typed_data)
+        signature = await self.build_order_signature(typed_data)
         return SignedOrderV1(**{**dataclasses.asdict(order), "signature": signature})
 
     def build_order(self, order_data: OrderDataV1) -> OrderV1:
@@ -93,10 +93,8 @@ class ExchangeOrderBuilderV1:
             },
         }
 
-    def build_order_signature(self, typed_data: dict) -> str:
-        encoded = encode_typed_data(full_message=typed_data)
-        signed = Account.sign_message(encoded, private_key=self.signer.private_key)
-        return "0x" + signed.signature.hex()
+    async def build_order_signature(self, typed_data: dict) -> str:
+        return prepend_zx(await self.signer.sign(self.build_order_hash(typed_data)))
 
     def build_order_hash(self, typed_data: dict) -> str:
         encoded = encode_typed_data(full_message=typed_data)

--- a/py_clob_client_v2/order_utils/exchange_order_builder_v2.py
+++ b/py_clob_client_v2/order_utils/exchange_order_builder_v2.py
@@ -1,8 +1,8 @@
 import dataclasses
 import time
-from eth_account import Account
 from eth_account.messages import encode_typed_data
 from eth_utils import keccak as _keccak
+from py_order_utils.utils import prepend_zx
 
 
 def _hash_message(msg) -> bytes:
@@ -39,10 +39,10 @@ class ExchangeOrderBuilderV2:
         self.signer = signer
         self.generate_salt = generate_salt
 
-    def build_signed_order(self, order_data: OrderDataV2) -> SignedOrderV2:
+    async def build_signed_order(self, order_data: OrderDataV2) -> SignedOrderV2:
         order = self.build_order(order_data)
         typed_data = self.build_order_typed_data(order)
-        signature = self.build_order_signature(typed_data)
+        signature = await self.build_order_signature(typed_data)
         return SignedOrderV2(**{**dataclasses.asdict(order), "signature": signature})
 
     def build_order(self, order_data: OrderDataV2) -> OrderV2:
@@ -102,10 +102,8 @@ class ExchangeOrderBuilderV2:
             },
         }
 
-    def build_order_signature(self, typed_data: dict) -> str:
-        encoded = encode_typed_data(full_message=typed_data)
-        signed = Account.sign_message(encoded, private_key=self.signer.private_key)
-        return "0x" + signed.signature.hex()
+    async def build_order_signature(self, typed_data: dict) -> str:
+        return prepend_zx(await self.signer.sign(self.build_order_hash(typed_data)))
 
     def build_order_hash(self, typed_data: dict) -> str:
         encoded = encode_typed_data(full_message=typed_data)

--- a/py_clob_client_v2/rfq/rfq_client.py
+++ b/py_clob_client_v2/rfq/rfq_client.py
@@ -309,7 +309,7 @@ class RfqClient:
     # Trade execution methods
     # =========================================================================
 
-    def accept_rfq_quote(self, params: AcceptQuoteParams) -> str:
+    async def accept_rfq_quote(self, params: AcceptQuoteParams) -> str:
         """
         Accept an RFQ quote (requester side).
 
@@ -339,7 +339,7 @@ class RfqClient:
             expiration=params.expiration,
         )
 
-        order = self._build_v1_order(order_args)
+        order = await self._build_v1_order(order_args)
 
         if not order:
             raise Exception("Error creating order")
@@ -371,7 +371,7 @@ class RfqClient:
             data=serialized_body,
         )
 
-    def approve_rfq_order(self, params: ApproveOrderParams) -> str:
+    async def approve_rfq_order(self, params: ApproveOrderParams) -> str:
         """
         Approve an RFQ order (quoter side).
 
@@ -406,7 +406,7 @@ class RfqClient:
             expiration=params.expiration,
         )
 
-        order = self._build_v1_order(order_args)
+        order = await self._build_v1_order(order_args)
 
         if not order:
             raise Exception("Error creating order")
@@ -454,7 +454,7 @@ class RfqClient:
     # Private helpers
     # =========================================================================
 
-    def _build_v1_order(self, order_args: OrderArgsV1):
+    async def _build_v1_order(self, order_args: OrderArgsV1):
         """
         Build a signed V1 order via the parent's order builder.
 
@@ -463,7 +463,7 @@ class RfqClient:
         """
         tick_size = self._parent._ClobClient__resolve_tick_size(order_args.token_id)
         neg_risk = self._parent.get_neg_risk(order_args.token_id)
-        return self._parent.builder.build_order(
+        return await self._parent.builder.build_order(
             order_args,
             CreateOrderOptions(tick_size=tick_size, neg_risk=neg_risk),
             version=1,

--- a/py_clob_client_v2/signer.py
+++ b/py_clob_client_v2/signer.py
@@ -1,22 +1,72 @@
+from typing import Awaitable, Callable, Optional, Union
+
 from eth_account import Account
+
+SignatureValue = Union[str, bytes]
+SignCallback = Callable[[str], Awaitable[SignatureValue]]
 
 
 class Signer:
-    def __init__(self, private_key: str, chain_id: int):
-        assert private_key is not None and chain_id is not None
+    def __init__(
+        self,
+        private_key: str = None,
+        chain_id: int = None,
+        address_override: str = None,
+        sign_callback_override: Optional[SignCallback] = None,
+    ):
+        if chain_id is None:
+            raise ValueError("chain_id is required")
+        if private_key is None and (
+            address_override is None or sign_callback_override is None
+        ):
+            raise ValueError(
+                "Signer requires a private_key or both address_override and "
+                "sign_callback_override"
+            )
 
         self.private_key = private_key
-        self.account = Account.from_key(private_key)
         self.chain_id = chain_id
+        self.address_override = address_override
+        self.sign_callback_override = sign_callback_override
+        self.account = Account.from_key(private_key) if private_key else None
 
     def address(self):
+        if self.address_override is not None:
+            return self.address_override
         return self.account.address
 
     def get_chain_id(self):
         return self.chain_id
 
-    def sign(self, message_hash):
+    async def sign(self, message_hash):
         """
-        Signs a message hash
+        Signs a 32-byte message hash.
         """
-        return Account._sign_hash(message_hash, self.private_key).signature.hex()
+        if self.sign_callback_override is not None:
+            signature = await self.sign_callback_override(message_hash)
+            return self._normalize_signature(signature)
+
+        signed = Account._sign_hash(
+            self._normalize_message_hash(message_hash),
+            private_key=self.private_key,
+        )
+        return signed.signature.hex()
+
+    def _normalize_message_hash(self, message_hash) -> bytes:
+        if isinstance(message_hash, str):
+            normalized = (
+                message_hash[2:] if message_hash.startswith("0x") else message_hash
+            )
+            return bytes.fromhex(normalized)
+        if isinstance(message_hash, (bytes, bytearray)):
+            return bytes(message_hash)
+        raise TypeError("message_hash must be a hex string or bytes")
+
+    def _normalize_signature(self, signature: SignatureValue) -> str:
+        if isinstance(signature, str):
+            return signature[2:] if signature.startswith("0x") else signature
+        if isinstance(signature, (bytes, bytearray)):
+            return bytes(signature).hex()
+        if hasattr(signature, "hex"):
+            return signature.hex()
+        raise TypeError("signature must be a hex string or bytes")

--- a/py_clob_client_v2/signing/eip712.py
+++ b/py_clob_client_v2/signing/eip712.py
@@ -14,7 +14,7 @@ def get_clob_auth_domain(chain_id: int):
     return make_domain(name=CLOB_DOMAIN_NAME, version=CLOB_VERSION, chainId=chain_id)
 
 
-def sign_clob_auth_message(signer: Signer, timestamp: int, nonce: int) -> str:
+async def sign_clob_auth_message(signer: Signer, timestamp: int, nonce: int) -> str:
     clob_auth_msg = ClobAuth(
         address=signer.address(),
         timestamp=str(timestamp),
@@ -25,4 +25,4 @@ def sign_clob_auth_message(signer: Signer, timestamp: int, nonce: int) -> str:
     auth_struct_hash = prepend_zx(
         keccak(clob_auth_msg.signable_bytes(get_clob_auth_domain(chain_id))).hex()
     )
-    return prepend_zx(signer.sign(auth_struct_hash))
+    return prepend_zx(await signer.sign(auth_struct_hash))

--- a/tests/headers/test_headers.py
+++ b/tests/headers/test_headers.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import datetime
 from unittest import TestCase
 
@@ -30,7 +31,7 @@ creds = ApiCreds(
 class TestHeaders(TestCase):
     def test_create_level_1_headers(self):
         # no nonce
-        headers = create_level_1_headers(signer)
+        headers = asyncio.run(create_level_1_headers(signer))
         self.assertIsNotNone(headers)
         self.assertEqual(headers[POLY_ADDRESS], signer.address())
         self.assertIsNotNone(headers[POLY_SIGNATURE])
@@ -39,7 +40,7 @@ class TestHeaders(TestCase):
         self.assertEqual(headers[POLY_NONCE], "0")
 
         # with nonce
-        headers = create_level_1_headers(signer, nonce=1012)
+        headers = asyncio.run(create_level_1_headers(signer, nonce=1012))
         self.assertIsNotNone(headers)
         self.assertEqual(headers[POLY_ADDRESS], signer.address())
         self.assertIsNotNone(headers[POLY_SIGNATURE])

--- a/tests/order_builder/test_builder.py
+++ b/tests/order_builder/test_builder.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest import TestCase
 
 from py_clob_client_v2.clob_types import (
@@ -23,6 +24,10 @@ chain_id = AMOY
 signer = Signer(private_key=private_key, chain_id=chain_id)
 
 TOKEN_ID = "71321045679252212594626385532706912750332728571942532289631379312455583992563"
+
+
+def run_async(coro):
+    return asyncio.run(coro)
 
 class TestOrderBuilder(TestCase):
 
@@ -479,10 +484,10 @@ class TestOrderBuilder(TestCase):
 
     def test_build_order_buy_0_1(self):
         builder = OrderBuilder(signer)
-        order = builder.build_order(
+        order = run_async(builder.build_order(
             OrderArgsV2(token_id=TOKEN_ID, price=0.5, size=100, side=BUY),
             CreateOrderOptions(tick_size="0.1", neg_risk=False),
-        )
+        ))
         self._assert_signed_order_v2(order)
         self.assertEqual(order.side, Side.BUY)
         self.assertEqual(order.makerAmount, "50000000")
@@ -490,10 +495,10 @@ class TestOrderBuilder(TestCase):
 
     def test_build_order_sell_0_1(self):
         builder = OrderBuilder(signer)
-        order = builder.build_order(
+        order = run_async(builder.build_order(
             OrderArgsV2(token_id=TOKEN_ID, price=0.5, size=100, side=SELL),
             CreateOrderOptions(tick_size="0.1", neg_risk=False),
-        )
+        ))
         self._assert_signed_order_v2(order)
         self.assertEqual(order.side, Side.SELL)
         self.assertEqual(order.makerAmount, "100000000")
@@ -502,10 +507,10 @@ class TestOrderBuilder(TestCase):
     def test_build_order_0_01(self):
         builder = OrderBuilder(signer)
         for side in [BUY, SELL]:
-            order = builder.build_order(
+            order = run_async(builder.build_order(
                 OrderArgsV2(token_id=TOKEN_ID, price=0.56, size=21.04, side=side),
                 CreateOrderOptions(tick_size="0.01", neg_risk=False),
-            )
+            ))
             self._assert_signed_order_v2(order)
             if side == BUY:
                 self.assertEqual(order.makerAmount, "11782400")
@@ -517,10 +522,10 @@ class TestOrderBuilder(TestCase):
     def test_build_order_0_001(self):
         builder = OrderBuilder(signer)
         for side in [BUY, SELL]:
-            order = builder.build_order(
+            order = run_async(builder.build_order(
                 OrderArgsV2(token_id=TOKEN_ID, price=0.056, size=21.04, side=side),
                 CreateOrderOptions(tick_size="0.001", neg_risk=False),
-            )
+            ))
             self._assert_signed_order_v2(order)
             if side == BUY:
                 self.assertEqual(order.makerAmount, "1178240")
@@ -532,10 +537,10 @@ class TestOrderBuilder(TestCase):
     def test_build_order_0_0001(self):
         builder = OrderBuilder(signer)
         for side in [BUY, SELL]:
-            order = builder.build_order(
+            order = run_async(builder.build_order(
                 OrderArgsV2(token_id=TOKEN_ID, price=0.0056, size=21.04, side=side),
                 CreateOrderOptions(tick_size="0.0001", neg_risk=False),
-            )
+            ))
             self._assert_signed_order_v2(order)
             if side == BUY:
                 self.assertEqual(order.makerAmount, "117824")
@@ -547,10 +552,10 @@ class TestOrderBuilder(TestCase):
     def test_build_order_precision(self):
         # price=0.82, size=20.0 — tests rounding precision at 0.01 tick
         builder = OrderBuilder(signer)
-        order = builder.build_order(
+        order = run_async(builder.build_order(
             OrderArgsV2(token_id=TOKEN_ID, price=0.82, size=20.0, side=BUY),
             CreateOrderOptions(tick_size="0.01", neg_risk=False),
-        )
+        ))
         self._assert_signed_order_v2(order)
         self.assertEqual(order.makerAmount, "16400000")
         self.assertEqual(order.takerAmount, "20000000")
@@ -559,115 +564,115 @@ class TestOrderBuilder(TestCase):
         builder = OrderBuilder(signer)
         for tick_size, price in [("0.1", 0.5), ("0.01", 0.56), ("0.001", 0.056), ("0.0001", 0.0056)]:
             for side in [BUY, SELL]:
-                order = builder.build_order(
+                order = run_async(builder.build_order(
                     OrderArgsV2(token_id=TOKEN_ID, price=price, size=10, side=side),
                     CreateOrderOptions(tick_size=tick_size, neg_risk=True),
-                )
+                ))
                 self._assert_signed_order_v2(order)
 
     def test_build_order_with_builder_code(self):
         builder = OrderBuilder(signer)
         builder_code = "0x" + "ab" * 32
-        order = builder.build_order(
+        order = run_async(builder.build_order(
             OrderArgsV2(token_id=TOKEN_ID, price=0.5, size=100, side=BUY, builder_code=builder_code),
             CreateOrderOptions(tick_size="0.1", neg_risk=False),
-        )
+        ))
         self._assert_signed_order_v2(order)
         self.assertEqual(order.builder, builder_code)
 
     def test_build_order_poly_proxy_signature_type(self):
         b = OrderBuilder(signer, signature_type=SignatureTypeV2.POLY_PROXY)
-        order = b.build_order(
+        order = run_async(b.build_order(
             OrderArgsV2(token_id=TOKEN_ID, price=0.5, size=10, side=BUY),
             CreateOrderOptions(tick_size="0.1", neg_risk=False),
-        )
+        ))
         self._assert_signed_order_v2(order)
         self.assertEqual(order.signatureType, SignatureTypeV2.POLY_PROXY)
 
     def test_build_order_gnosis_safe_signature_type(self):
         b = OrderBuilder(signer, signature_type=SignatureTypeV2.POLY_GNOSIS_SAFE)
-        order = b.build_order(
+        order = run_async(b.build_order(
             OrderArgsV2(token_id=TOKEN_ID, price=0.5, size=10, side=BUY),
             CreateOrderOptions(tick_size="0.1", neg_risk=False),
-        )
+        ))
         self._assert_signed_order_v2(order)
         self.assertEqual(order.signatureType, SignatureTypeV2.POLY_GNOSIS_SAFE)
 
     def test_build_market_order_buy_0_1(self):
         builder = OrderBuilder(signer)
-        order = builder.build_market_order(
+        order = run_async(builder.build_market_order(
             MarketOrderArgsV2(token_id=TOKEN_ID, amount=50, side=BUY, price=0.5),
             CreateOrderOptions(tick_size="0.1", neg_risk=False),
-        )
+        ))
         self._assert_signed_order_v2(order)
         self.assertEqual(order.side, Side.BUY)
 
     def test_build_market_order_sell_0_1(self):
         builder = OrderBuilder(signer)
-        order = builder.build_market_order(
+        order = run_async(builder.build_market_order(
             MarketOrderArgsV2(token_id=TOKEN_ID, amount=100, side=SELL, price=0.5),
             CreateOrderOptions(tick_size="0.1", neg_risk=False),
-        )
+        ))
         self._assert_signed_order_v2(order)
         self.assertEqual(order.side, Side.SELL)
 
     def test_build_market_order_0_01(self):
         builder = OrderBuilder(signer)
         for side in [BUY, SELL]:
-            order = builder.build_market_order(
+            order = run_async(builder.build_market_order(
                 MarketOrderArgsV2(token_id=TOKEN_ID, amount=21.04, side=side, price=0.56),
                 CreateOrderOptions(tick_size="0.01", neg_risk=False),
-            )
+            ))
             self._assert_signed_order_v2(order)
 
     def test_build_market_order_0_001(self):
         builder = OrderBuilder(signer)
         for side in [BUY, SELL]:
-            order = builder.build_market_order(
+            order = run_async(builder.build_market_order(
                 MarketOrderArgsV2(token_id=TOKEN_ID, amount=21.04, side=side, price=0.056),
                 CreateOrderOptions(tick_size="0.001", neg_risk=False),
-            )
+            ))
             self._assert_signed_order_v2(order)
 
     def test_build_market_order_0_0001(self):
         builder = OrderBuilder(signer)
         for side in [BUY, SELL]:
-            order = builder.build_market_order(
+            order = run_async(builder.build_market_order(
                 MarketOrderArgsV2(token_id=TOKEN_ID, amount=10, side=side, price=0.0056),
                 CreateOrderOptions(tick_size="0.0001", neg_risk=False),
-            )
+            ))
             self._assert_signed_order_v2(order)
 
     def test_build_market_order_neg_risk(self):
         builder = OrderBuilder(signer)
         for tick_size, price in [("0.1", 0.5), ("0.01", 0.56), ("0.001", 0.056), ("0.0001", 0.0056)]:
             for side in [BUY, SELL]:
-                order = builder.build_market_order(
+                order = run_async(builder.build_market_order(
                     MarketOrderArgsV2(token_id=TOKEN_ID, amount=10, side=side, price=price),
                     CreateOrderOptions(tick_size=tick_size, neg_risk=True),
-                )
+                ))
                 self._assert_signed_order_v2(order)
 
     def test_build_market_order_with_builder_code(self):
         builder = OrderBuilder(signer)
         builder_code = "0x" + "cd" * 32
-        order = builder.build_market_order(
+        order = run_async(builder.build_market_order(
             MarketOrderArgsV2(
                 token_id=TOKEN_ID, amount=50, side=BUY, price=0.5, builder_code=builder_code
             ),
             CreateOrderOptions(tick_size="0.1", neg_risk=False),
-        )
+        ))
         self._assert_signed_order_v2(order)
         self.assertEqual(order.builder, builder_code)
 
     def test_build_order_v1_has_fee_rate_bps_nonce_taker(self):
         builder = OrderBuilder(signer)
-        order = builder.build_order(
+        order = run_async(builder.build_order(
             OrderArgsV1(token_id=TOKEN_ID, price=0.5, size=21.04, side=BUY, nonce=7),
             CreateOrderOptions(tick_size="0.01", neg_risk=False),
             version=1,
             fee_rate_bps=1000,
-        )
+        ))
         self._assert_signed_order_v1(order)
         self.assertEqual(order.feeRateBps, "1000")
         self.assertEqual(order.nonce, "7")
@@ -676,26 +681,26 @@ class TestOrderBuilder(TestCase):
     def test_build_order_v2_has_no_fee_rate_bps_nonce(self):
         builder = OrderBuilder(signer)
         builder_code = "0x" + "ab" * 32
-        order = builder.build_order(
+        order = run_async(builder.build_order(
             OrderArgsV2(
                 token_id=TOKEN_ID, price=0.5, size=21.04, side=BUY,
                 builder_code=builder_code, expiration=1234567,
             ),
             CreateOrderOptions(tick_size="0.01", neg_risk=False),
             version=2,
-        )
+        ))
         self._assert_signed_order_v2(order)
         self.assertEqual(order.builder, builder_code)
         self.assertEqual(order.expiration, "1234567")
 
     def test_build_market_order_v1_has_fee_rate_bps_nonce_taker(self):
         builder = OrderBuilder(signer)
-        order = builder.build_market_order(
+        order = run_async(builder.build_market_order(
             MarketOrderArgsV1(token_id=TOKEN_ID, amount=21.04, side=BUY, price=0.5, nonce=3),
             CreateOrderOptions(tick_size="0.01", neg_risk=False),
             version=1,
             fee_rate_bps=500,
-        )
+        ))
         self._assert_signed_order_v1(order)
         self.assertEqual(order.feeRateBps, "500")
         self.assertEqual(order.nonce, "3")
@@ -704,13 +709,13 @@ class TestOrderBuilder(TestCase):
     def test_build_market_order_v2_has_no_fee_rate_bps_nonce(self):
         builder = OrderBuilder(signer)
         builder_code = "0x" + "ef" * 32
-        order = builder.build_market_order(
+        order = run_async(builder.build_market_order(
             MarketOrderArgsV2(
                 token_id=TOKEN_ID, amount=21.04, side=BUY, price=0.5, builder_code=builder_code
             ),
             CreateOrderOptions(tick_size="0.01", neg_risk=False),
             version=2,
-        )
+        ))
         self._assert_signed_order_v2(order)
         self.assertEqual(order.builder, builder_code)
 

--- a/tests/order_utils/test_exchange_order_builder_v1.py
+++ b/tests/order_utils/test_exchange_order_builder_v1.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest import TestCase
 
 from py_clob_client_v2.constants import AMOY, ZERO_ADDRESS
@@ -34,6 +35,21 @@ _ORDER_DATA = OrderDataV1(
     signer=signer.address(),
     expiration="0",
     signatureType=SignatureTypeV1.EOA,
+)
+
+
+def run_async(coro):
+    return asyncio.run(coro)
+
+
+async def sign_callback_override(message_hash):
+    return await signer.sign(message_hash)
+
+
+callback_signer = Signer(
+    chain_id=chain_id,
+    address_override=signer.address(),
+    sign_callback_override=sign_callback_override,
 )
 
 class TestExchangeOrderBuilderV1CTF(TestCase):
@@ -139,7 +155,7 @@ class TestExchangeOrderBuilderV1CTF(TestCase):
     def test_build_order_signature_random_salt(self):
         order = self.builder.build_order(_ORDER_DATA)
         typed_data = self.builder.build_order_typed_data(order)
-        sig = self.builder.build_order_signature(typed_data)
+        sig = run_async(self.builder.build_order_signature(typed_data))
         self.assertIsNotNone(sig)
         self.assertNotEqual(sig, "")
 
@@ -147,7 +163,20 @@ class TestExchangeOrderBuilderV1CTF(TestCase):
         self.builder.generate_salt = lambda: FIXED_SALT
         order = self.builder.build_order(_ORDER_DATA)
         typed_data = self.builder.build_order_typed_data(order)
-        sig = self.builder.build_order_signature(typed_data)
+        sig = run_async(self.builder.build_order_signature(typed_data))
+        self.assertEqual(
+            sig,
+            "0x302cd9abd0b5fcaa202a344437ec0b6660da984e24ae9ad915a592a90facf5a51bb8a873cd8d270f070217fea1986531d5eec66f1162a81f66e026db653bf7ce1c",
+        )
+
+    def test_build_order_signature_specific_salt_with_sign_callback_override(self):
+        callback_builder = ExchangeOrderBuilderV1(
+            contract_config.exchange, chain_id, callback_signer
+        )
+        callback_builder.generate_salt = lambda: FIXED_SALT
+        order = callback_builder.build_order(_ORDER_DATA)
+        typed_data = callback_builder.build_order_typed_data(order)
+        sig = run_async(callback_builder.build_order_signature(typed_data))
         self.assertEqual(
             sig,
             "0x302cd9abd0b5fcaa202a344437ec0b6660da984e24ae9ad915a592a90facf5a51bb8a873cd8d270f070217fea1986531d5eec66f1162a81f66e026db653bf7ce1c",
@@ -171,7 +200,7 @@ class TestExchangeOrderBuilderV1CTF(TestCase):
         )
 
     def test_build_signed_order_random_salt(self):
-        signed = self.builder.build_signed_order(_ORDER_DATA)
+        signed = run_async(self.builder.build_signed_order(_ORDER_DATA))
         self.assertIsNotNone(signed)
         self.assertNotEqual(signed.salt, "")
         self.assertEqual(signed.maker, signer.address())
@@ -189,7 +218,7 @@ class TestExchangeOrderBuilderV1CTF(TestCase):
 
     def test_build_signed_order_specific_salt(self):
         self.builder.generate_salt = lambda: FIXED_SALT
-        signed = self.builder.build_signed_order(_ORDER_DATA)
+        signed = run_async(self.builder.build_signed_order(_ORDER_DATA))
         self.assertEqual(signed.salt, FIXED_SALT)
         self.assertEqual(signed.maker, signer.address())
         self.assertEqual(signed.signer, signer.address())
@@ -235,7 +264,7 @@ class TestExchangeOrderBuilderV1NegRisk(TestCase):
         self.builder.generate_salt = lambda: FIXED_SALT
         order = self.builder.build_order(_ORDER_DATA)
         typed_data = self.builder.build_order_typed_data(order)
-        sig = self.builder.build_order_signature(typed_data)
+        sig = run_async(self.builder.build_order_signature(typed_data))
         self.assertEqual(
             sig,
             "0x1b3646ef347e5bd144c65bd3357ba19c12c12abaeedae733cf8579bc51a2752c0454c3bc6b236957e393637982c769b8dc0706c0f5c399983d933850afd1cbcd1c",
@@ -253,7 +282,7 @@ class TestExchangeOrderBuilderV1NegRisk(TestCase):
 
     def test_build_signed_order_specific_salt(self):
         self.builder.generate_salt = lambda: FIXED_SALT
-        signed = self.builder.build_signed_order(_ORDER_DATA)
+        signed = run_async(self.builder.build_signed_order(_ORDER_DATA))
         self.assertEqual(signed.salt, FIXED_SALT)
         self.assertEqual(
             signed.signature,

--- a/tests/signing/test_eip712.py
+++ b/tests/signing/test_eip712.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest import TestCase
 
 from py_clob_client_v2.constants import AMOY
@@ -10,10 +11,30 @@ chain_id = AMOY
 signer = Signer(private_key=private_key, chain_id=chain_id)
 
 
+def run_async(coro):
+    return asyncio.run(coro)
+
+
 class TestEIP712(TestCase):
     def test_sign_clob_auth_message(self):
-        signature = sign_clob_auth_message(signer, 10000000, 23)
+        signature = run_async(sign_clob_auth_message(signer, 10000000, 23))
         self.assertIsNotNone(signature)
+        self.assertEqual(
+            signature,
+            "0xf62319a987514da40e57e2f4d7529f7bac38f0355bd88bb5adbb3768d80de6c1682518e0af677d5260366425f4361e7b70c25ae232aff0ab2331e2b164a1aedc1b",
+        )
+
+    def test_sign_clob_auth_message_with_sign_callback_override(self):
+        async def sign_callback_override(message_hash):
+            return await signer.sign(message_hash)
+
+        callback_signer = Signer(
+            chain_id=chain_id,
+            address_override=signer.address(),
+            sign_callback_override=sign_callback_override,
+        )
+
+        signature = run_async(sign_clob_auth_message(callback_signer, 10000000, 23))
         self.assertEqual(
             signature,
             "0xf62319a987514da40e57e2f4d7529f7bac38f0355bd88bb5adbb3768d80de6c1682518e0af677d5260366425f4361e7b70c25ae232aff0ab2331e2b164a1aedc1b",

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest import TestCase
 
 from py_clob_client_v2.clob_types import CreateOrderOptions, OrderArgsV2, OrderType
@@ -22,6 +23,10 @@ signer = Signer(private_key=private_key, chain_id=chain_id)
 builder = OrderBuilder(signer)
 
 TOKEN_ID = "71321045679252212594626385532706912750332728571942532289631379312455583992563"
+
+
+def run_async(coro):
+    return asyncio.run(coro)
 
 
 class TestUtilities(TestCase):
@@ -114,7 +119,7 @@ class TestUtilities(TestCase):
     def test_order_to_json_v2_0_1(self):
         for side in [BUY, SELL]:
             for order_type in [OrderType.GTC, OrderType.GTD]:
-                order = builder.build_order(
+                order = run_async(builder.build_order(
                     OrderArgsV2(
                         token_id=TOKEN_ID,
                         price=0.5,
@@ -122,7 +127,7 @@ class TestUtilities(TestCase):
                         side=side,
                     ),
                     CreateOrderOptions(tick_size="0.1", neg_risk=False),
-                )
+                ))
                 result = order_to_json_v2(order, "owner", order_type)
                 o = result["order"]
                 self.assertIsNotNone(o["salt"])
@@ -147,10 +152,10 @@ class TestUtilities(TestCase):
 
     def test_order_to_json_v2_0_01(self):
         for side in [BUY, SELL]:
-            order = builder.build_order(
+            order = run_async(builder.build_order(
                 OrderArgsV2(token_id=TOKEN_ID, price=0.56, size=21.04, side=side),
                 CreateOrderOptions(tick_size="0.01", neg_risk=False),
-            )
+            ))
             result = order_to_json_v2(order, "owner", OrderType.GTC)
             o = result["order"]
             self.assertIsNotNone(o["salt"])
@@ -161,10 +166,10 @@ class TestUtilities(TestCase):
 
     def test_order_to_json_v2_0_001(self):
         for side in [BUY, SELL]:
-            order = builder.build_order(
+            order = run_async(builder.build_order(
                 OrderArgsV2(token_id=TOKEN_ID, price=0.056, size=21.04, side=side),
                 CreateOrderOptions(tick_size="0.001", neg_risk=False),
-            )
+            ))
             result = order_to_json_v2(order, "owner", OrderType.GTC)
             o = result["order"]
             self.assertIsNotNone(o["salt"])
@@ -174,10 +179,10 @@ class TestUtilities(TestCase):
 
     def test_order_to_json_v2_0_0001(self):
         for side in [BUY, SELL]:
-            order = builder.build_order(
+            order = run_async(builder.build_order(
                 OrderArgsV2(token_id=TOKEN_ID, price=0.0056, size=21.04, side=side),
                 CreateOrderOptions(tick_size="0.0001", neg_risk=False),
-            )
+            ))
             result = order_to_json_v2(order, "owner", OrderType.GTC)
             o = result["order"]
             self.assertIsNotNone(o["salt"])
@@ -188,10 +193,10 @@ class TestUtilities(TestCase):
     def test_order_to_json_v2_neg_risk(self):
         for tick_size, price in [("0.1", 0.5), ("0.01", 0.56), ("0.001", 0.056), ("0.0001", 0.0056)]:
             for side in [BUY, SELL]:
-                order = builder.build_order(
+                order = run_async(builder.build_order(
                     OrderArgsV2(token_id=TOKEN_ID, price=price, size=10, side=side),
                     CreateOrderOptions(tick_size=tick_size, neg_risk=True),
-                )
+                ))
                 result = order_to_json_v2(order, "owner", OrderType.GTC)
                 o = result["order"]
                 self.assertIsNotNone(o["salt"])
@@ -201,10 +206,10 @@ class TestUtilities(TestCase):
                 self.assertNotIn("feeRateBps", o)
 
     def test_order_to_json_v2_defer_exec(self):
-        order = builder.build_order(
+        order = run_async(builder.build_order(
             OrderArgsV2(token_id=TOKEN_ID, price=0.5, size=10, side=BUY),
             CreateOrderOptions(tick_size="0.1", neg_risk=False),
-        )
+        ))
         result = order_to_json_v2(order, "owner", OrderType.GTC, defer_exec=True)
         self.assertTrue(result["deferExec"])
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Converts key auth/signing and order-construction paths to `async`, which is a breaking API change for callers and could surface subtle await/loop integration issues in signing and request header generation.
> 
> **Overview**
> Adds a *custom signer* option by extending `Signer` to support an `address_override` plus an async `sign_callback_override`, enabling external wallets/HSMs to produce signatures instead of requiring a local private key.
> 
> To support async signing, updates Level-1 auth header generation and EIP-712 signing to be async, and propagates this through order-building and related client APIs (`create_order`, `create_market_order`, `create_and_post_*`, API key creation/derivation, and RFQ accept/approve). A new async retry helper (`_retry_on_version_update_async`) is introduced, and tests are updated to run coroutines and to validate the callback-based signer path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5038acd4346d32ba84921927522545277c125bdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->