### PR TITLE
chore: OrderType as a real enum

### DIFF
--- a/py_clob_client_v2/clob_types.py
+++ b/py_clob_client_v2/clob_types.py
@@ -1,12 +1,13 @@
 from typing import Any, Dict, List, Optional, Tuple, Union
 from dataclasses import dataclass, field, asdict
+from enum import Enum
 from json import dumps
 from typing import Literal
 
 from .constants import ZERO_ADDRESS, BYTES32_ZERO
 
 
-class OrderType:
+class OrderType(str, Enum):
     GTC = "GTC"
     FOK = "FOK"
     GTD = "GTD"


### PR DESCRIPTION
## Summary
- Redefines `OrderType` in `py_clob_client_v2/clob_types.py` as `class OrderType(str, Enum)` so member access yields an `OrderType` instance instead of `Literal['GTC' | 'FOK' | 'GTD' | 'FAK']`.
- Resolves the spurious type-checker error reported in #28 when passing values like `OrderType.FAK` to methods such as `post_order`.
- The `str` mixin preserves runtime behavior: equality with raw strings still holds, and JSON serialization still emits the bare value (e.g. `"GTC"`), so no other source files need to change.

`enum.StrEnum` was intentionally not used because it requires Python 3.11+, while `setup.py` declares `python_requires=">=3.9.10"`.

## Test plan
- [x] `make test` — full suite passes (176/176)
- [x] Sanity check: `isinstance(OrderType.FAK, OrderType)` is `True`, `OrderType.FOK == "FOK"`, `json.dumps({"orderType": OrderType.GTC}) == '{"orderType": "GTC"}'`

Closes #28

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: limited to a type definition change that should be runtime-compatible with existing string comparisons and serialization, with minimal blast radius.
> 
> **Overview**
> **Improves `OrderType` typing** by redefining it as `class OrderType(str, Enum)` instead of a plain constants container.
> 
> This makes accesses like `OrderType.FAK` produce an actual `OrderType` value while keeping it string-like for equality checks and JSON serialization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22182e01ebedc30d6bf09ebe24ac6742e9c7f21e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->