### PR TITLE
Make OrderType, SideString, AssetType, and PriceHistoryInterval proper str Enums

### DIFF
--- a/py_clob_client_v2/client.py
+++ b/py_clob_client_v2/client.py
@@ -658,7 +658,7 @@ class ClobClient:
         p = {"signature_type": int(self.builder.signature_type)}
         if params:
             if params.asset_type:
-                p["asset_type"] = str(params.asset_type)
+                p["asset_type"] = params.asset_type.value
             if params.token_id:
                 p["token_id"] = params.token_id
         return self._get(f"{self.host}{GET_BALANCE_ALLOWANCE}", headers=headers, params=p)
@@ -668,7 +668,7 @@ class ClobClient:
         p = {"signature_type": int(self.builder.signature_type)}
         if params:
             if params.asset_type:
-                p["asset_type"] = str(params.asset_type)
+                p["asset_type"] = params.asset_type.value
             if params.token_id:
                 p["token_id"] = params.token_id
         return self._get(f"{self.host}{UPDATE_BALANCE_ALLOWANCE}", headers=headers, params=p)

--- a/py_clob_client_v2/client.py
+++ b/py_clob_client_v2/client.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from .clob_types import (
     ApiCreds,
+    AssetType,
     BalanceAllowanceParams,
     BookParams,
     BuilderConfig,
@@ -24,6 +25,7 @@ from .clob_types import (
     OrderType,
     PartialCreateOrderOptions,
     PostOrdersArgs,
+    PriceHistoryInterval,
     PricesHistoryParams,
     RewardsMarketsParams,
     TickSize,
@@ -407,7 +409,7 @@ class ClobClient:
         if params.fidelity is not None:
             p["fidelity"] = params.fidelity
         if params.interval is not None:
-            p["interval"] = params.interval
+            p["interval"] = params.interval.value if isinstance(params.interval, PriceHistoryInterval) else params.interval
         return self._get(f"{self.host}{GET_PRICES_HISTORY}", params=p)
 
     def calculate_market_price(
@@ -658,7 +660,7 @@ class ClobClient:
         p = {"signature_type": int(self.builder.signature_type)}
         if params:
             if params.asset_type:
-                p["asset_type"] = params.asset_type.value
+                p["asset_type"] = params.asset_type.value if isinstance(params.asset_type, AssetType) else params.asset_type
             if params.token_id:
                 p["token_id"] = params.token_id
         return self._get(f"{self.host}{GET_BALANCE_ALLOWANCE}", headers=headers, params=p)
@@ -668,7 +670,7 @@ class ClobClient:
         p = {"signature_type": int(self.builder.signature_type)}
         if params:
             if params.asset_type:
-                p["asset_type"] = params.asset_type.value
+                p["asset_type"] = params.asset_type.value if isinstance(params.asset_type, AssetType) else params.asset_type
             if params.token_id:
                 p["token_id"] = params.token_id
         return self._get(f"{self.host}{UPDATE_BALANCE_ALLOWANCE}", headers=headers, params=p)

--- a/py_clob_client_v2/clob_types.py
+++ b/py_clob_client_v2/clob_types.py
@@ -1,12 +1,13 @@
 from typing import Any, Dict, List, Optional, Tuple, Union
 from dataclasses import dataclass, field, asdict
+from enum import Enum
 from json import dumps
 from typing import Literal
 
 from .constants import ZERO_ADDRESS, BYTES32_ZERO
 
 
-class OrderType:
+class OrderType(str, Enum):
     GTC = "GTC"
     FOK = "FOK"
     GTD = "GTD"

--- a/py_clob_client_v2/clob_types.py
+++ b/py_clob_client_v2/clob_types.py
@@ -223,7 +223,7 @@ class OrderBookSummary:
         return dumps(self.__dict__, separators=(",", ":"))
 
 
-class AssetType:
+class AssetType(str, Enum):
     COLLATERAL = "COLLATERAL"
     CONDITIONAL = "CONDITIONAL"
 
@@ -425,7 +425,7 @@ class BuilderApiKeyResponse:
     revoked_at: Optional[str] = None
 
 
-class PriceHistoryInterval:
+class PriceHistoryInterval(str, Enum):
     MAX = "max"
     ONE_WEEK = "1w"
     ONE_DAY = "1d"

--- a/py_clob_client_v2/http_helpers/helpers.py
+++ b/py_clob_client_v2/http_helpers/helpers.py
@@ -186,7 +186,7 @@ def add_balance_allowance_params_to_url(
     if params:
         url = url + "?"
         if params.asset_type:
-            url = build_query_params(url, "asset_type", str(params.asset_type))
+            url = build_query_params(url, "asset_type", params.asset_type.value)
         if params.token_id:
             url = build_query_params(url, "token_id", params.token_id)
         if params.signature_type is not None:

--- a/py_clob_client_v2/http_helpers/helpers.py
+++ b/py_clob_client_v2/http_helpers/helpers.py
@@ -4,6 +4,7 @@ import time
 import httpx
 
 from py_clob_client_v2.clob_types import (
+    AssetType,
     BalanceAllowanceParams,
     DropNotificationParams,
     OpenOrderParams,
@@ -186,7 +187,8 @@ def add_balance_allowance_params_to_url(
     if params:
         url = url + "?"
         if params.asset_type:
-            url = build_query_params(url, "asset_type", params.asset_type.value)
+            asset_type_value = params.asset_type.value if isinstance(params.asset_type, AssetType) else params.asset_type
+            url = build_query_params(url, "asset_type", asset_type_value)
         if params.token_id:
             url = build_query_params(url, "token_id", params.token_id)
         if params.signature_type is not None:

--- a/py_clob_client_v2/order_utils/model/side.py
+++ b/py_clob_client_v2/order_utils/model/side.py
@@ -1,4 +1,4 @@
-from enum import IntEnum
+from enum import Enum, IntEnum
 
 
 class Side(IntEnum):
@@ -6,6 +6,6 @@ class Side(IntEnum):
     SELL = 1
 
 
-class SideString:
+class SideString(str, Enum):
     BUY = "BUY"
     SELL = "SELL"


### PR DESCRIPTION
`OrderType`, `SideString`, `AssetType`, and `PriceHistoryInterval` are currently plain classes with string class attributes, which means e.g. `OrderType.GTC` is typed as `str` rather than `OrderType`. Anyone writing `order_type: OrderType = OrderType.GTC` in their own code gets a type error from mypy/pyright/ty and has to suppress it.

This converts all four to `(str, Enum)` — the same pattern `MatchType` already uses in `rfq/rfq_types.py`. I went with the `(str, Enum)` mixin rather than `enum.StrEnum` because `setup.py` declares `python_requires=">=3.9.10"` and `StrEnum` only landed in 3.11. The `IntEnum`s (`Side`, `SignatureTypeV1`, `SignatureTypeV2`) are intentionally left alone since they map to integer values used on-chain and over the wire.

`OrderType` and `SideString` are pure type-annotation fixes — members are still `str` instances, equality with raw string literals (e.g. `order_type == "GTC"`) keeps working, and the values only flow into `json.dumps` bodies, which reads the underlying `str` value rather than `__str__`.

`AssetType` and `PriceHistoryInterval` need one extra fix worth a closer look. Their values flow into `httpx` query params, and `httpx` encodes parameter values via `str(value)` — which on a `(str, Enum)` mixin returns `'AssetType.COLLATERAL'` rather than `'COLLATERAL'` (the well-known reason `enum.StrEnum` exists in 3.11+). Without the fix, this would silently produce invalid request URLs like `?asset_type=AssetType.COLLATERAL` and `?interval=PriceHistoryInterval.MAX`. The four affected call sites (`client.py:410`, `client.py:661`, `client.py:671`, `http_helpers/helpers.py:189`) now extract `.value` when given an enum member, falling back to the raw value otherwise so existing callers passing plain strings (e.g. `interval="max"`, valid under `PricesHistoryParams.interval: str`) keep working.

Verified empirically with `httpx.Request(..., params={'interval': PriceHistoryInterval.MAX}).url` before/after the fix. Full suite passes (176 tests); the existing `test_add_balance_allowance_params_to_url` asserts the literal URL `asset_type=COLLATERAL` and serves as a regression check.

This would also close https://github.com/Polymarket/py-clob-client-v2/issues/28 