### PR TITLE
Fix float rounding drift in order amount calculations

### DIFF
--- a/py_clob_client_v2/order_builder/helpers.py
+++ b/py_clob_client_v2/order_builder/helpers.py
@@ -1,25 +1,37 @@
-from math import floor, ceil
-from decimal import Decimal
+from decimal import Decimal, ROUND_CEILING, ROUND_FLOOR, ROUND_HALF_UP
+
+
+TOKEN_DECIMAL_SCALE = Decimal("1000000")
+
+
+def _as_decimal(x: float) -> Decimal:
+    return Decimal(str(x))
+
+
+def _quantum(sig_digits: int) -> Decimal:
+    return Decimal(1).scaleb(-sig_digits)
 
 
 def round_down(x: float, sig_digits: int) -> float:
-    return floor(x * (10**sig_digits)) / (10**sig_digits)
+    return float(_as_decimal(x).quantize(_quantum(sig_digits), rounding=ROUND_FLOOR))
 
 
 def round_normal(x: float, sig_digits: int) -> float:
-    return round(x * (10**sig_digits)) / (10**sig_digits)
+    return float(_as_decimal(x).quantize(_quantum(sig_digits), rounding=ROUND_HALF_UP))
 
 
 def round_up(x: float, sig_digits: int) -> float:
-    return ceil(x * (10**sig_digits)) / (10**sig_digits)
+    return float(_as_decimal(x).quantize(_quantum(sig_digits), rounding=ROUND_CEILING))
 
 
 def to_token_decimals(x: float) -> int:
-    f = (10**6) * x
-    if decimal_places(f) > 0:
-        f = round_normal(f, 0)
-    return int(f)
+    return int(
+        (_as_decimal(x) * TOKEN_DECIMAL_SCALE).quantize(
+            Decimal("1"), rounding=ROUND_HALF_UP
+        )
+    )
 
 
 def decimal_places(x: float) -> int:
-    return abs(Decimal(x.__str__()).as_tuple().exponent)
+    exponent = _as_decimal(x).as_tuple().exponent
+    return abs(exponent) if exponent < 0 else 0

--- a/tests/order_builder/test_decimal_order_amounts.py
+++ b/tests/order_builder/test_decimal_order_amounts.py
@@ -1,0 +1,44 @@
+from unittest import TestCase
+
+from py_clob_client_v2.order_builder.builder import OrderBuilder, ROUNDING_CONFIG
+from py_clob_client_v2.order_builder.constants import BUY, SELL
+from py_clob_client_v2.order_utils.model import Side
+
+
+class TestDecimalOrderAmounts(TestCase):
+    def setUp(self):
+        self.builder = OrderBuilder(signer=None, funder="0x" + "0" * 40)
+
+    def test_limit_buy_preserves_cent_boundary_sizes(self):
+        cases = [
+            (16.90, 0.30, 5_070_000, 16_900_000),
+            (33.30, 0.30, 9_990_000, 33_300_000),
+            (66.60, 0.15, 9_990_000, 66_600_000),
+        ]
+
+        for size, price, expected_maker, expected_taker in cases:
+            with self.subTest(size=size, price=price):
+                side, maker, taker = self.builder.get_order_amounts(
+                    BUY, size, price, ROUNDING_CONFIG["0.01"]
+                )
+
+                self.assertEqual(side, Side.BUY)
+                self.assertEqual(maker, expected_maker)
+                self.assertEqual(taker, expected_taker)
+
+    def test_limit_sell_preserves_cent_boundary_sizes(self):
+        cases = [
+            (16.90, 0.30, 16_900_000, 5_070_000),
+            (33.30, 0.30, 33_300_000, 9_990_000),
+            (66.60, 0.15, 66_600_000, 9_990_000),
+        ]
+
+        for size, price, expected_maker, expected_taker in cases:
+            with self.subTest(size=size, price=price):
+                side, maker, taker = self.builder.get_order_amounts(
+                    SELL, size, price, ROUNDING_CONFIG["0.01"]
+                )
+
+                self.assertEqual(side, Side.SELL)
+                self.assertEqual(maker, expected_maker)
+                self.assertEqual(taker, expected_taker)


### PR DESCRIPTION
## Summary
- Use Decimal-based quantization for order-builder rounding helpers.
- Preserve cent-boundary sizes like 16.90, 33.30, and 66.60 when converting limit order amounts to token decimals.
- Add focused buy/sell regression coverage for 0.01 tick-size order amounts.

## Motivation
Float arithmetic can round valid cent-boundary order sizes down before token decimal conversion. For example, a 16.90 size at 0.30 price can produce 5,067,000 instead of 5,070,000 maker amount, creating invalid sub-cent order amounts.

The Decimal rounding uses ROUND_HALF_UP for normal rounding to match the positive-value behavior of the TypeScript v2 client's Math.round path.

Closes #68.

## Tests
- python -m pytest tests/order_builder/test_decimal_order_amounts.py tests/order_builder/test_helpers.py -q
- python -m pytest -q
- python -m black --check py_clob_client_v2/order_builder/helpers.py tests/order_builder/test_decimal_order_amounts.py
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core order amount rounding/conversion logic used to compute maker/taker amounts; subtle rounding behavior changes could affect order validity at certain tick sizes, but scope is contained and covered by new regression tests.
> 
> **Overview**
> Switches order-builder rounding helpers from float/math-based rounding to `Decimal.quantize` with explicit `ROUND_FLOOR`/`ROUND_CEILING`/`ROUND_HALF_UP`, and updates `to_token_decimals`/`decimal_places` to avoid float drift when scaling to 6-decimal token units.
> 
> Adds regression tests ensuring limit buy/sell amount calculations at `0.01` tick size preserve cent-boundary sizes (e.g., `16.90` at `0.30`) when converted to maker/taker token decimals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0c69894f3e4a372db87cd0779d5bcf8511b0c0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->