### PR TITLE
docs: recommend new unified py-sdk in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!NOTE]
+> We've released a new unified SDK that combines all our REST APIs and WebSockets into one package. We recommend [Polymarket/py-sdk](https://github.com/Polymarket/py-sdk) for new projects.
+
 # PY Polymarket CLOB Client V2
 
 Python client for the Polymarket CLOB (v2)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only README addition with no runtime or security impact.
> 
> **Overview**
> Adds a **GitHub note** at the top of `README.md` pointing new projects to the unified [Polymarket/py-sdk](https://github.com/Polymarket/py-sdk) (REST + WebSockets) instead of relying on this CLOB-only client alone.
> 
> No code, config, or dependency changes—documentation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdf3da9183a08270bec1de657375901d2a70c6d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->