### PR TITLE
fix: silence default stderr logging via NullHandler (closes #36)

### DIFF
--- a/py_clob_client_v2/__init__.py
+++ b/py_clob_client_v2/__init__.py
@@ -1,3 +1,9 @@
+import logging as _logging
+
+# Library default: do not emit log records when the consuming application has
+# not configured logging. See https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library
+_logging.getLogger(__name__).addHandler(_logging.NullHandler())
+
 from .client import ClobClient
 from .fees import adjust_buy_amount_for_fees
 from .order_utils import SignatureTypeV2, Side


### PR DESCRIPTION
## Summary

Adds a `NullHandler` to the package's top-level logger so `py_clob_client_v2` does not emit log records via Python's `lastResort` handler when the consuming application has not configured logging.

This is the standard library-logging pattern recommended in the [Python logging cookbook](https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library):

> "If a library user does not configure logging, and library code makes logging calls, then ... a one-off message 'No handlers could be found for logger X.Y.Z' is printed to the console."

Without this change, modules that log at `ERROR` (e.g. `http_helpers/helpers.py:73` and `:89`, both prefixed `[py_clob_client_v2]`) print to `stderr` by default, which breaks curses-based terminal UIs and prevents callers from handling errors fully on their own.

Closes #36.

## Change

```python
import logging as _logging
_logging.getLogger(__name__).addHandler(_logging.NullHandler())
```

Added at the top of `py_clob_client_v2/__init__.py` before the public imports. The underscore on the import prevents `from py_clob_client_v2 import *` from re-exporting `logging`.

## Behaviour

| Caller's logging setup | Before this PR | After this PR |
|---|---|---|
| No logging configured | SDK errors print to stderr via `lastResort` | Silent |
| `logging.basicConfig(...)` configured | SDK errors go to user's handlers (unchanged) | SDK errors go to user's handlers (unchanged) |
| User opts in: `logging.getLogger("py_clob_client_v2").setLevel(...)` | Works | Works |

## Test plan

- [x] Manual check: import `py_clob_client_v2` in a fresh interpreter with no logging config; confirm no warning is printed.
- [x] Manual check: configure root logger; confirm SDK errors still propagate to the configured handler.
- [ ] CI passes.

Happy to add a regression test in `tests/` if maintainers prefer.