### PR TITLE
feat: add slippage fee calculation

### DIFF
--- a/py_clob_client_v2/__init__.py
+++ b/py_clob_client_v2/__init__.py
@@ -1,4 +1,5 @@
 from .client import ClobClient
+from .fees import adjust_buy_amount_for_fees
 from .order_utils import SignatureTypeV2, Side
 from .clob_types import (
     PriceHistoryInterval,
@@ -49,6 +50,8 @@ __all__ = [
     "ClobClient",
     "SignatureTypeV2",
     "Side",
+    # Fee utilities
+    "adjust_buy_amount_for_fees",
     "PriceHistoryInterval",
     # Order input types
     "OrderArgsV1",

--- a/py_clob_client_v2/client.py
+++ b/py_clob_client_v2/client.py
@@ -105,6 +105,7 @@ from .endpoints import (
     VERSION,
 )
 from .exceptions import PolyException
+from .fees import adjust_buy_amount_for_fees, validate_fee_slippage
 from .headers.headers import create_level_1_headers, create_level_2_headers
 from .http_helpers.helpers import (
     delete,
@@ -112,12 +113,12 @@ from .http_helpers.helpers import (
     parse_drop_notification_params,
     post,
 )
-from .order_builder.builder import OrderBuilder
+from .order_builder.builder import OrderBuilder, ROUNDING_CONFIG
+from .order_builder.helpers import round_normal
 from .clob_types import RequestArgs
 from .rfq import RfqClient
 from .signer import Signer
 from .utilities import (
-    adjust_market_buy_amount,
     generate_orderbook_summary_hash,
     is_tick_size_smaller,
     parse_raw_orderbook_summary,
@@ -158,12 +159,15 @@ class ClobClient:
         builder_config: Optional[BuilderConfig] = None,
         use_server_time: bool = False,
         retry_on_error: bool = False,
+        fee_slippage: float = 0,
     ):
         self.host = host.rstrip("/")
         self.chain_id = chain_id
         self.use_server_time = use_server_time
         self.retry_on_error = retry_on_error
         self.builder_config = builder_config
+        self.fee_slippage = fee_slippage
+        validate_fee_slippage(self.fee_slippage)
 
         self.signer = Signer(key, chain_id) if key else None
         self.creds = creds
@@ -723,12 +727,29 @@ class ClobClient:
                 f"invalid price ({order_args.price}), min: {ts} - max: {1 - ts}"
             )
 
+        order_args.price = round_normal(order_args.price, ROUNDING_CONFIG[tick_size].price)
+
+        version = self.__resolve_version()
+
+        if (
+            version == 2
+            and (order_args.side == "BUY" or order_args.side == Side.BUY)
+            and getattr(order_args, "user_usdc_balance", None) is not None
+        ):
+            adjusted = self._adjust_buy_amount_for_balance(
+                token_id,
+                order_args.size * order_args.price,
+                order_args.price,
+                order_args.user_usdc_balance,
+                getattr(order_args, "builder_code", None),
+            )
+            order_args.size = adjusted / order_args.price
+
         neg_risk = (
             options.neg_risk
             if (options and options.neg_risk is not None)
             else self.get_neg_risk(token_id)
         )
-        version = self.__resolve_version()
 
         user_fee_rate_bps = getattr(order_args, "fee_rate_bps", None) or None
         fee_rate_bps = self.__resolve_fee_rate_bps(token_id, user_fee_rate_bps) if version == 1 else None
@@ -775,20 +796,12 @@ class ClobClient:
         builder_code = getattr(order_args, "builder_code", BYTES32_ZERO)
 
         if (order_args.side == "BUY" or order_args.side == Side.BUY) and getattr(order_args, "user_usdc_balance", None):
-            self.__ensure_builder_fee_rate_cached(builder_code)
-            builder_taker_fee_rate = (
-                self.__builder_fee_rates[builder_code].taker
-                if builder_code and builder_code != BYTES32_ZERO and builder_code in self.__builder_fee_rates
-                else 0
-            )
-            fi = self.__fee_infos.get(token_id) or FeeInfo()
-            order_args.amount = adjust_market_buy_amount(
+            order_args.amount = self._adjust_buy_amount_for_balance(
+                token_id,
                 order_args.amount,
-                order_args.user_usdc_balance,
                 order_args.price,
-                fi.rate or 0.0,
-                fi.exponent or 0.0,
-                builder_taker_fee_rate,
+                order_args.user_usdc_balance,
+                builder_code,
             )
 
         neg_risk = (
@@ -1041,6 +1054,33 @@ class ClobClient:
 
     def get_market_trades_events(self, condition_id: str):
         return self._get(f"{self.host}{GET_MARKET_TRADES_EVENTS}{condition_id}")
+
+    def _get_builder_taker_fee_rate(self, builder_code: Optional[str] = None) -> float:
+        if not builder_code or builder_code == BYTES32_ZERO:
+            return 0
+        self.__ensure_builder_fee_rate_cached(builder_code)
+        return self.__builder_fee_rates.get(builder_code, BuilderFeeRate()).taker
+
+    def _adjust_buy_amount_for_balance(
+        self,
+        token_id: str,
+        amount: float,
+        price: float,
+        user_usdc_balance: float,
+        builder_code: Optional[str] = None,
+    ) -> float:
+        self.__ensure_market_info_cached(token_id)
+        builder_taker_fee_rate = self._get_builder_taker_fee_rate(builder_code)
+        fi = self.__fee_infos.get(token_id) or FeeInfo()
+        return adjust_buy_amount_for_fees(
+            amount,
+            price,
+            user_usdc_balance,
+            fi.rate or 0.0,
+            fi.exponent or 0.0,
+            builder_taker_fee_rate,
+            self.fee_slippage,
+        )
 
     def __resolve_tick_size(self, token_id: str, tick_size: TickSize = None) -> TickSize:
         min_tick_size = self.get_tick_size(token_id)

--- a/py_clob_client_v2/client.py
+++ b/py_clob_client_v2/client.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from dataclasses import asdict, is_dataclass
+from dataclasses import asdict, is_dataclass, replace as dataclass_replace
 from typing import Optional
 
 from .clob_types import (
@@ -727,10 +727,11 @@ class ClobClient:
                 f"invalid price ({order_args.price}), min: {ts} - max: {1 - ts}"
             )
 
-        order_args.price = round_normal(order_args.price, ROUNDING_CONFIG[tick_size].price)
+        price = round_normal(order_args.price, ROUNDING_CONFIG[tick_size].price)
 
         version = self.__resolve_version()
 
+        size = order_args.size
         if (
             version == 2
             and (order_args.side == "BUY" or order_args.side == Side.BUY)
@@ -738,12 +739,12 @@ class ClobClient:
         ):
             adjusted = self._adjust_buy_amount_for_balance(
                 token_id,
-                order_args.size * order_args.price,
-                order_args.price,
+                size * price,
+                price,
                 order_args.user_usdc_balance,
                 getattr(order_args, "builder_code", None),
             )
-            order_args.size = adjusted / order_args.price
+            size = adjusted / price
 
         neg_risk = (
             options.neg_risk
@@ -754,8 +755,9 @@ class ClobClient:
         user_fee_rate_bps = getattr(order_args, "fee_rate_bps", None) or None
         fee_rate_bps = self.__resolve_fee_rate_bps(token_id, user_fee_rate_bps) if version == 1 else None
 
+        build_args = dataclass_replace(order_args, price=price, size=size)
         return self.builder.build_order(
-            order_args,
+            build_args,
             CreateOrderOptions(tick_size=tick_size, neg_risk=neg_risk),
             version=version,
             fee_rate_bps=fee_rate_bps,
@@ -775,18 +777,19 @@ class ClobClient:
             token_id, options.tick_size if options else None
         )
 
-        if not order_args.price:
-            order_args.price = self.calculate_market_price(
+        price = order_args.price
+        if not price:
+            price = self.calculate_market_price(
                 token_id,
                 order_args.side,
                 order_args.amount,
                 order_args.order_type,
             )
 
-        if not price_valid(order_args.price, tick_size):
+        if not price_valid(price, tick_size):
             ts = float(tick_size)
             raise PolyException(
-                f"invalid price ({order_args.price}), min: {ts} - max: {1 - ts}"
+                f"invalid price ({price}), min: {ts} - max: {1 - ts}"
             )
 
         if self.builder_config and self.builder_config.builder_code:
@@ -795,11 +798,12 @@ class ClobClient:
 
         builder_code = getattr(order_args, "builder_code", BYTES32_ZERO)
 
+        amount = order_args.amount
         if (order_args.side == "BUY" or order_args.side == Side.BUY) and getattr(order_args, "user_usdc_balance", None):
-            order_args.amount = self._adjust_buy_amount_for_balance(
+            amount = self._adjust_buy_amount_for_balance(
                 token_id,
-                order_args.amount,
-                order_args.price,
+                amount,
+                price,
                 order_args.user_usdc_balance,
                 builder_code,
             )
@@ -814,8 +818,9 @@ class ClobClient:
         user_fee_rate_bps = getattr(order_args, "fee_rate_bps", None) or None
         fee_rate_bps = self.__resolve_fee_rate_bps(token_id, user_fee_rate_bps) if version == 1 else None
 
+        build_args = dataclass_replace(order_args, price=price, amount=amount)
         return self.builder.build_market_order(
-            order_args,
+            build_args,
             CreateOrderOptions(tick_size=tick_size, neg_risk=neg_risk),
             version=version,
             fee_rate_bps=fee_rate_bps,

--- a/py_clob_client_v2/clob_types.py
+++ b/py_clob_client_v2/clob_types.py
@@ -96,6 +96,10 @@ class OrderArgsV2:
     metadata: str = BYTES32_ZERO
     """Optional metadata (bytes32) attached to the order"""
 
+    user_usdc_balance: Optional[float] = None
+    """User's collateral balance. If provided and insufficient to cover size*price + fees, the order
+    size is reduced"""
+
 
 # Alias: default to V2
 OrderArgs = OrderArgsV2

--- a/py_clob_client_v2/fees.py
+++ b/py_clob_client_v2/fees.py
@@ -1,0 +1,40 @@
+import math
+
+MIN_FEE_SLIPPAGE_PERCENTAGE = 1
+MAX_FEE_SLIPPAGE_PERCENTAGE = 100
+
+
+def validate_fee_slippage(fee_slippage: float) -> None:
+    try:
+        is_finite = math.isfinite(fee_slippage)
+    except (TypeError, ValueError):
+        is_finite = False
+    if (
+        not is_finite
+        or fee_slippage < 0
+        or fee_slippage > MAX_FEE_SLIPPAGE_PERCENTAGE
+        or (fee_slippage > 0 and fee_slippage < MIN_FEE_SLIPPAGE_PERCENTAGE)
+    ):
+        raise ValueError("fee_slippage must be 0 or a percentage between 1 and 100")
+
+
+def adjust_buy_amount_for_fees(
+    amount: float,
+    price: float,
+    user_usdc_balance: float,
+    fee_rate: float,
+    fee_exponent: float,
+    builder_taker_fee_rate: float,
+    fee_slippage: float = 0,
+) -> float:
+    validate_fee_slippage(fee_slippage)
+    platform_fee_rate = fee_rate * (price * (1 - price)) ** fee_exponent
+    effective_platform_fee_rate = platform_fee_rate * (1 + fee_slippage / 100)
+    fee_base_amount = min(amount, user_usdc_balance)
+    platform_fee = (fee_base_amount / price) * effective_platform_fee_rate
+    builder_fee = fee_base_amount * builder_taker_fee_rate
+    total_cost = amount + platform_fee + builder_fee
+
+    if user_usdc_balance <= total_cost:
+        return max(user_usdc_balance - platform_fee - builder_fee, 0)
+    return amount

--- a/py_clob_client_v2/utilities.py
+++ b/py_clob_client_v2/utilities.py
@@ -1,8 +1,8 @@
 import hashlib
 import json
-from decimal import Decimal
 
 from .clob_types import OrderBookSummary, OrderSummary, TickSize
+from .fees import adjust_buy_amount_for_fees
 
 
 def parse_raw_orderbook_summary(raw_obs: dict) -> OrderBookSummary:
@@ -56,22 +56,9 @@ def adjust_market_buy_amount(
     fee_exponent: float,
     builder_taker_fee_rate: float = 0,
 ) -> float:
-    """Return fee-adjusted amount for a market buy, or the original amount if balance is sufficient."""
-    d_amount = Decimal(str(amount))
-    d_price = Decimal(str(price))
-    d_balance = Decimal(str(user_usdc_balance))
-    d_fee_rate = Decimal(str(fee_rate))
-    d_fee_exponent = Decimal(str(fee_exponent))
-    d_btr = Decimal(str(builder_taker_fee_rate))
-    base = float(d_price * (Decimal("1") - d_price))
-    d_pfr = d_fee_rate * Decimal(str(base ** float(d_fee_exponent)))
-
-    platform_fee = d_amount / d_price * d_pfr
-    total_cost = d_amount + platform_fee + d_amount * d_btr
-    if d_balance <= total_cost:
-        divisor = Decimal("1") + d_pfr / d_price + d_btr
-        return float(d_balance / divisor)
-    return amount
+    return adjust_buy_amount_for_fees(
+        amount, price, user_usdc_balance, fee_rate, fee_exponent, builder_taker_fee_rate
+    )
 
 
 def is_tick_size_smaller(a: TickSize, b: TickSize) -> bool:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="py_clob_client_v2",
-    version="1.0.1rc1",
+    version="1.0.1",
     author="Polymarket Engineering",
     author_email="engineering@polymarket.com",
     maintainer="Polymarket Engineering",

--- a/tests/order_builder/test_builder.py
+++ b/tests/order_builder/test_builder.py
@@ -817,9 +817,8 @@ class TestAdjustMarketBuyAmount(TestCase):
 
     # --- conditional: adjustment triggers ---
 
-    def test_no_adjustment_when_balance_exactly_covers_cost(self):
-        # when balance == total_cost, the adjustment formula algebraically recovers the
-        # original amount — user can afford exactly amount + fees, so nothing changes
+    def test_balance_equals_total_cost_returns_amount(self):
+        # balance = amount + fee(amount): enters branch but result == amount
         amount, price, fee_rate, fee_exponent = 50, 0.5, 0.25, 2
         total = self._total_cost(amount, price, fee_rate, fee_exponent)
         result = adjust_market_buy_amount(amount, total, price, fee_rate, fee_exponent)
@@ -831,49 +830,49 @@ class TestAdjustMarketBuyAmount(TestCase):
         result = adjust_market_buy_amount(amount, 48.0, price, fee_rate, fee_exponent)
         self.assertLess(result, amount)
 
-    # --- invariant: adjusted + fees(adjusted) == budget ---
+    # --- invariant: adjusted = balance - reserved_fee ---
 
-    def test_invariant_platform_fee_only(self):
+    def test_platform_fee_only_reserves_original_fee(self):
+        # reserved_fee = fee(amount), adjusted = balance - reserved_fee
         budget, price, fee_rate, fee_exponent = 50, 0.5, 0.25, 2
         result = adjust_market_buy_amount(budget, budget, price, fee_rate, fee_exponent)
-        self.assertAlmostEqual(
-            self._total_cost(result, price, fee_rate, fee_exponent), budget, places=10
-        )
+        reserved_fee = self._total_cost(budget, price, fee_rate, fee_exponent) - budget
+        self.assertAlmostEqual(result, budget - reserved_fee, places=10)
 
-    def test_invariant_builder_fee_only(self):
+    def test_builder_fee_only_reserves_original_fee(self):
         budget, price, builder_rate = 50, 0.5, 0.01
         result = adjust_market_buy_amount(budget, budget, price, 0, 0, builder_rate)
-        self.assertAlmostEqual(
-            self._total_cost(result, price, 0, 0, builder_rate), budget, places=10
-        )
+        reserved_fee = self._total_cost(budget, price, 0, 0, builder_rate) - budget
+        self.assertAlmostEqual(result, budget - reserved_fee, places=10)
 
-    def test_invariant_combined_fees(self):
+    def test_combined_fees_reserves_original_fee(self):
         budget, price, fee_rate, fee_exponent, builder_rate = 50, 0.5, 0.25, 2, 0.01
         result = adjust_market_buy_amount(budget, budget, price, fee_rate, fee_exponent, builder_rate)
-        self.assertAlmostEqual(
-            self._total_cost(result, price, fee_rate, fee_exponent, builder_rate), budget, places=10
-        )
+        reserved_fee = self._total_cost(budget, price, fee_rate, fee_exponent, builder_rate) - budget
+        self.assertAlmostEqual(result, budget - reserved_fee, places=10)
 
-    def test_invariant_various_prices(self):
+    def test_reserves_original_fee_at_various_prices(self):
         budget, fee_rate, fee_exponent = 50, 0.25, 2
         for price in [0.05, 0.1, 0.3, 0.5, 0.7, 0.9, 0.95]:
             result = adjust_market_buy_amount(budget, budget, price, fee_rate, fee_exponent)
+            reserved_fee = self._total_cost(budget, price, fee_rate, fee_exponent) - budget
             self.assertAlmostEqual(
-                self._total_cost(result, price, fee_rate, fee_exponent),
-                budget,
+                result,
+                budget - reserved_fee,
                 places=10,
-                msg=f"invariant failed at price={price}",
+                msg=f"fee reservation failed at price={price}",
             )
 
-    def test_invariant_various_budgets(self):
+    def test_reserves_original_fee_at_various_budgets(self):
         price, fee_rate, fee_exponent = 0.5, 0.25, 2
         for budget in [1.0, 10.0, 50.0, 100.0, 1000.0]:
             result = adjust_market_buy_amount(budget, budget, price, fee_rate, fee_exponent)
+            reserved_fee = self._total_cost(budget, price, fee_rate, fee_exponent) - budget
             self.assertAlmostEqual(
-                self._total_cost(result, price, fee_rate, fee_exponent),
-                budget,
+                result,
+                budget - reserved_fee,
                 places=10,
-                msg=f"invariant failed at budget={budget}",
+                msg=f"fee reservation failed at budget={budget}",
             )
 
     # --- edge cases ---

--- a/tests/test_client_order_adjustment.py
+++ b/tests/test_client_order_adjustment.py
@@ -76,9 +76,7 @@ class TestClientOrderFeeAdjustment(unittest.TestCase):
         # takerAmount = 96.25 * 1e6 = 96250000
         self.assertEqual(signed.makerAmount, "48125000")
         self.assertEqual(signed.takerAmount, "96250000")
-        # original object was mutated by price rounding (0.5 → 0.5) and size adjustment
-        # but user_usdc_balance is unchanged
-        self.assertEqual(order.user_usdc_balance, 50)
+        self.assertEqual(order.size, 100)
 
     def test_adjusts_v2_buy_limit_when_price_rounds_up_to_tick(self):
         client = _make_cached_client(fee_slippage=20)
@@ -129,7 +127,7 @@ class TestClientOrderFeeAdjustment(unittest.TestCase):
         # takerAmount = 96.24 * 1e6 = 96240000
         self.assertEqual(signed.makerAmount, "48120000")
         self.assertEqual(signed.takerAmount, "96240000")
-        self.assertEqual(order.amount, 48.125)  # mutated to adjusted amount
+        self.assertEqual(order.amount, 50)
 
     def test_v2_buy_limit_unchanged_without_user_usdc_balance(self):
         client = _make_cached_client(fee_slippage=20)

--- a/tests/test_client_order_adjustment.py
+++ b/tests/test_client_order_adjustment.py
@@ -1,0 +1,157 @@
+import unittest
+
+from py_clob_client_v2.client import ClobClient
+from py_clob_client_v2.clob_types import FeeInfo, MarketOrderArgsV2, OrderArgsV2
+from py_clob_client_v2.constants import AMOY
+from py_clob_client_v2.order_utils.model.side import Side
+
+# publicly known private key
+PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+TOKEN_ID = "123"
+FEE_RATE = 0.25
+FEE_EXPONENT = 2
+
+
+def _make_cached_client(fee_slippage: float = 0) -> ClobClient:
+    client = ClobClient(
+        host="https://clob.polymarket.com",
+        chain_id=AMOY,
+        key=PRIVATE_KEY,
+        fee_slippage=fee_slippage,
+    )
+    client._ClobClient__tick_sizes[TOKEN_ID] = "0.01"
+    client._ClobClient__neg_risk[TOKEN_ID] = False
+    client._ClobClient__fee_infos[TOKEN_ID] = FeeInfo(rate=FEE_RATE, exponent=FEE_EXPONENT)
+    client._ClobClient__cached_version = 2
+    return client
+
+
+class TestClobClientFeeSlippage(unittest.TestCase):
+    def test_defaults_to_zero(self):
+        client = ClobClient(host="https://clob.polymarket.com", chain_id=AMOY)
+        self.assertEqual(client.fee_slippage, 0)
+
+    def test_accepts_float_between_1_and_100(self):
+        client = ClobClient(
+            host="https://clob.polymarket.com",
+            chain_id=AMOY,
+            fee_slippage=12.5,
+        )
+        self.assertEqual(client.fee_slippage, 12.5)
+
+    def test_rejects_invalid_values_at_init(self):
+        def make(fee_slippage):
+            ClobClient(
+                host="https://clob.polymarket.com",
+                chain_id=AMOY,
+                fee_slippage=fee_slippage,
+            )
+
+        with self.assertRaises(ValueError):
+            make(0.5)
+        with self.assertRaises(ValueError):
+            make(101)
+        with self.assertRaises(ValueError):
+            make(float("nan"))
+
+
+class TestClientOrderFeeAdjustment(unittest.TestCase):
+    def test_adjusts_v2_buy_limit_size_when_user_usdc_balance_provided(self):
+        client = _make_cached_client(fee_slippage=20)
+        order = OrderArgsV2(
+            token_id=TOKEN_ID,
+            price=0.5,
+            size=100,
+            side=Side.BUY,
+            user_usdc_balance=50,
+        )
+        signed = client.create_order(order)
+        # requestedNotional = 100 * 0.5 = 50
+        # feeBaseAmount = min(50, 50) = 50
+        # feeRateComponent = 0.25 * (0.5 * 0.5)^2 = 0.015625
+        # paddedFee = (50 / 0.5) * 0.015625 * 1.2 = 1.875
+        # adjustedNotional = 50 - 1.875 = 48.125
+        # adjustedSize = 48.125 / 0.5 = 96.25
+        # makerAmount = 96.25 * 0.5 * 1e6 = 48125000
+        # takerAmount = 96.25 * 1e6 = 96250000
+        self.assertEqual(signed.makerAmount, "48125000")
+        self.assertEqual(signed.takerAmount, "96250000")
+        # original object was mutated by price rounding (0.5 → 0.5) and size adjustment
+        # but user_usdc_balance is unchanged
+        self.assertEqual(order.user_usdc_balance, 50)
+
+    def test_adjusts_v2_buy_limit_when_price_rounds_up_to_tick(self):
+        client = _make_cached_client(fee_slippage=20)
+        order = OrderArgsV2(
+            token_id=TOKEN_ID,
+            price=0.506,  # rounds to 0.51 for tick 0.01
+            size=100,
+            side=Side.BUY,
+            user_usdc_balance=50,
+        )
+        signed = client.create_order(order)
+        signed_notional = int(signed.makerAmount) / 1_000_000
+        signed_shares = int(signed.takerAmount) / 1_000_000
+        # Input price 0.505 rounds to 0.51
+        # requestedNotional = 100 * 0.51 = 51, balance = 50
+        # feeBaseAmount = min(51, 50) = 50
+        # feeRateComponent = 0.25 * (0.51 * 0.49)^2 = 0.0156125025
+        # paddedFeeRate = 0.0156125025 * 1.2 = 0.018735003
+        # paddedFee = (50 / 0.51) * 0.018735003 ≈ 1.836765
+        # adjustedNotional = 50 - 1.836765 = 48.163235
+        # adjustedSize = 48.163235 / 0.51 ≈ 94.437...
+        # roundDown(94.437, 2) = 94.43
+        # makerAmount = 94.43 * 0.51 * 1e6 = 48159300
+        # takerAmount = 94.43 * 1e6 = 94430000
+        self.assertEqual(signed.makerAmount, "48159300")
+        self.assertEqual(signed.takerAmount, "94430000")
+        self.assertAlmostEqual(signed_notional, 48.1593, places=4)
+        self.assertAlmostEqual(signed_shares, 94.43, places=2)
+
+    def test_adjusts_v2_buy_market_amount_when_user_usdc_balance_provided(self):
+        client = _make_cached_client(fee_slippage=20)
+        order = MarketOrderArgsV2(
+            token_id=TOKEN_ID,
+            price=0.5,
+            amount=50,
+            side=Side.BUY,
+            user_usdc_balance=50,
+        )
+        signed = client.create_market_order(order)
+        # market BUY amount is already cash notional
+        # feeBaseAmount = min(50, 50) = 50
+        # paddedFee = (50 / 0.5) * 0.015625 * 1.2 = 1.875
+        # adjustedAmount = 50 - 1.875 = 48.125
+        # roundDown(48.125, 2) = 48.12
+        # rawPrice = roundDown(0.5, 2) = 0.5
+        # takerAmount = 48.12 / 0.5 = 96.24
+        # makerAmount = 48.12 * 1e6 = 48120000
+        # takerAmount = 96.24 * 1e6 = 96240000
+        self.assertEqual(signed.makerAmount, "48120000")
+        self.assertEqual(signed.takerAmount, "96240000")
+        self.assertEqual(order.amount, 48.125)  # mutated to adjusted amount
+
+    def test_v2_buy_limit_unchanged_without_user_usdc_balance(self):
+        client = _make_cached_client(fee_slippage=20)
+        order = OrderArgsV2(
+            token_id=TOKEN_ID,
+            price=0.5,
+            size=100,
+            side=Side.BUY,
+        )
+        signed = client.create_order(order)
+        self.assertEqual(signed.makerAmount, "50000000")
+        self.assertEqual(signed.takerAmount, "100000000")
+
+    def test_v2_sell_limit_unchanged_with_user_usdc_balance(self):
+        client = _make_cached_client(fee_slippage=20)
+        order = OrderArgsV2(
+            token_id=TOKEN_ID,
+            price=0.5,
+            size=100,
+            side=Side.SELL,
+            user_usdc_balance=50,
+        )
+        signed = client.create_order(order)
+        self.assertEqual(signed.makerAmount, "100000000")
+        self.assertEqual(signed.takerAmount, "50000000")

--- a/tests/test_fee_calculations.py
+++ b/tests/test_fee_calculations.py
@@ -1,14 +1,24 @@
 import unittest
-from py_clob_client_v2.utilities import adjust_market_buy_amount
+from py_clob_client_v2.fees import adjust_buy_amount_for_fees, validate_fee_slippage
 
 
-def calculate_platform_fee(amount_usd: float, price: float, fee_rate: float, fee_exponent: float) -> float:
+def calculate_platform_fee(
+    amount_usd: float,
+    price: float,
+    fee_rate: float,
+    fee_exponent: float,
+    fee_slippage: float = 0,
+) -> float:
     platform_fee_rate = fee_rate * (price * (1 - price)) ** fee_exponent
-    return (amount_usd / price) * platform_fee_rate
+    return (amount_usd / price) * platform_fee_rate * (1 + fee_slippage / 100)
 
 
 def calculate_builder_fee(amount_usd: float, builder_taker_fee_rate: float) -> float:
     return amount_usd * builder_taker_fee_rate
+
+
+def round_to(value: float, decimals: int = 12) -> float:
+    return round(value, decimals)
 
 
 class TestPlatformFee(unittest.TestCase):
@@ -18,58 +28,82 @@ class TestPlatformFee(unittest.TestCase):
 
     def test_price_0_5(self):
         price = 0.5
-        self.assertAlmostEqual(calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent), 1.5625, delta=1e-6)
+        self.assertEqual(
+            round_to(calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent)),
+            1.5625,
+        )
 
     def test_price_0_3(self):
         price = 0.3
-        self.assertAlmostEqual(calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent), 1.1025, delta=1e-6)
+        self.assertEqual(
+            round_to(calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent)),
+            1.1025,
+        )
 
     def test_price_0_1(self):
         price = 0.1
-        self.assertAlmostEqual(calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent), 0.2025, delta=1e-6)
+        self.assertEqual(
+            round_to(calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent)),
+            0.2025,
+        )
 
     def test_price_0_05(self):
         price = 0.05
-        self.assertAlmostEqual(calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent), 0.05640625, delta=1e-6)
+        self.assertEqual(
+            round_to(calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent)),
+            0.05640625,
+        )
 
     def test_price_0_01(self):
         price = 0.01
-        self.assertAlmostEqual(calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent), 0.00245025, delta=1e-6)
+        self.assertEqual(
+            round_to(calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent)),
+            0.00245025,
+        )
 
     def test_price_0_7_symmetric_with_0_3(self):
         price = 0.7
-        self.assertAlmostEqual(calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent), 1.1025, delta=1e-6)
+        self.assertEqual(
+            round_to(calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent)),
+            1.1025,
+        )
 
     def test_price_0_9_symmetric_with_0_1(self):
         price = 0.9
-        self.assertAlmostEqual(calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent), 0.2025, delta=1e-6)
+        self.assertEqual(
+            round_to(calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent)),
+            0.2025,
+        )
 
     def test_price_0_95_symmetric_with_0_05(self):
         price = 0.95
-        self.assertAlmostEqual(calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent), 0.05640625, delta=1e-6)
+        self.assertEqual(
+            round_to(calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent)),
+            0.05640625,
+        )
 
     def test_price_0_99_symmetric_with_0_01(self):
         price = 0.99
-        self.assertAlmostEqual(calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent), 0.00245025, delta=1e-6)
+        self.assertEqual(
+            round_to(calculate_platform_fee(self.contracts * price, price, self.fee_rate, self.fee_exponent)),
+            0.00245025,
+        )
 
     def test_price_0_5_c_125_5(self):
         price = 0.5
         c = 125.5
-        self.assertAlmostEqual(calculate_platform_fee(c * price, price, self.fee_rate, self.fee_exponent), 1.9609375, delta=1e-6)
+        self.assertEqual(
+            round_to(calculate_platform_fee(c * price, price, self.fee_rate, self.fee_exponent)),
+            1.9609375,
+        )
 
 
 class TestBuilderFee(unittest.TestCase):
     def test_1pct_100_tokens_at_50c(self):
-        price = 0.5
-        contracts = 100
-        builder_taker_fee_rate = 0.01
-        self.assertAlmostEqual(calculate_builder_fee(contracts * price, builder_taker_fee_rate), 0.5, delta=1e-6)
+        self.assertEqual(calculate_builder_fee(100 * 0.5, 0.01), 0.5)
 
     def test_5pct_200_tokens_at_75c(self):
-        price = 0.75
-        contracts = 200
-        builder_taker_fee_rate = 0.05
-        self.assertAlmostEqual(calculate_builder_fee(contracts * price, builder_taker_fee_rate), 7.5, delta=1e-6)
+        self.assertEqual(calculate_builder_fee(200 * 0.75, 0.05), 7.5)
 
 
 class TestCombinedFee(unittest.TestCase):
@@ -84,9 +118,9 @@ class TestCombinedFee(unittest.TestCase):
         platform_fee = calculate_platform_fee(amount_usd, price, fee_rate, fee_exponent)
         builder_fee = calculate_builder_fee(amount_usd, builder_taker_fee_rate)
 
-        self.assertAlmostEqual(platform_fee, 1.5625, delta=1e-6)
-        self.assertAlmostEqual(builder_fee, 0.5, delta=1e-6)
-        self.assertAlmostEqual(platform_fee + builder_fee, 2.0625, delta=1e-6)
+        self.assertEqual(platform_fee, 1.5625)
+        self.assertEqual(builder_fee, 0.5)
+        self.assertEqual(platform_fee + builder_fee, 2.0625)
 
 
 class TestAdjustBuyAmountForFees(unittest.TestCase):
@@ -95,7 +129,7 @@ class TestAdjustBuyAmountForFees(unittest.TestCase):
 
     def test_no_adjustment_zero_fees(self):
         amount = 50
-        result = adjust_market_buy_amount(amount, amount, 0.5, 0, 0, 0)
+        result = adjust_buy_amount_for_fees(amount, 0.5, amount, 0, 0, 0)
         self.assertEqual(result, amount)
 
     def test_no_adjustment_balance_above_total_cost(self):
@@ -104,107 +138,257 @@ class TestAdjustBuyAmountForFees(unittest.TestCase):
         platform_fee = calculate_platform_fee(amount, price, self.fee_rate, self.fee_exponent)
         total_cost = amount + platform_fee
         balance = total_cost + 1
-        result = adjust_market_buy_amount(amount, balance, price, self.fee_rate, self.fee_exponent, 0)
+        result = adjust_buy_amount_for_fees(amount, price, balance, self.fee_rate, self.fee_exponent, 0)
         self.assertEqual(result, amount)
 
-    def test_boundary_balance_equals_total_cost(self):
+    def test_balance_exactly_equal_to_amount_plus_reserved_fee_returns_amount(self):
+        # balance = amount + fee(amount) triggers the branch but result == amount
         amount = 50
         price = 0.5
         platform_fee = calculate_platform_fee(amount, price, self.fee_rate, self.fee_exponent)
         total_cost = amount + platform_fee
-        result = adjust_market_buy_amount(amount, total_cost, price, self.fee_rate, self.fee_exponent, 0)
-        platform_fee_rate = self.fee_rate * (price * (1 - price)) ** self.fee_exponent
-        expected = total_cost / (1 + platform_fee_rate / price)
-        self.assertAlmostEqual(result, expected, places=9)
+        result = adjust_buy_amount_for_fees(amount, price, total_cost, self.fee_rate, self.fee_exponent, 0)
+        self.assertEqual(platform_fee, 1.5625)
+        self.assertEqual(total_cost, 51.5625)
+        self.assertEqual(result, 50)
 
-    def test_platform_fee_only_adjusted_plus_fee_equals_amount(self):
+    def test_platform_fee_only_reserves_original_fee(self):
         amount = 50
         price = 0.5
-        adjusted = adjust_market_buy_amount(amount, amount, price, self.fee_rate, self.fee_exponent, 0)
-        fee = calculate_platform_fee(adjusted, price, self.fee_rate, self.fee_exponent)
-        self.assertAlmostEqual(adjusted + fee, amount, places=9)
+        adjusted = adjust_buy_amount_for_fees(amount, price, amount, self.fee_rate, self.fee_exponent, 0)
+        original_fee = calculate_platform_fee(amount, price, self.fee_rate, self.fee_exponent)
+        adjusted_fee = calculate_platform_fee(adjusted, price, self.fee_rate, self.fee_exponent)
+        self.assertEqual(original_fee, 1.5625)
+        self.assertEqual(adjusted, 48.4375)
+        self.assertEqual(adjusted_fee, 1.513671875)
+        self.assertEqual(adjusted + adjusted_fee, 49.951171875)
 
-    def test_builder_fee_only_adjusted_plus_fee_equals_amount(self):
-        amount = 50
-        price = 0.5
-        builder_taker_fee_rate = 0.01
-        adjusted = adjust_market_buy_amount(amount, amount, price, 0, 0, builder_taker_fee_rate)
-        fee = calculate_builder_fee(adjusted, builder_taker_fee_rate)
-        self.assertAlmostEqual(adjusted + fee, amount, places=9)
-
-    def test_platform_and_builder_fee_adjusted_plus_fees_equals_amount(self):
+    def test_builder_fee_only_reserves_original_fee(self):
         amount = 50
         price = 0.5
         builder_taker_fee_rate = 0.01
-        adjusted = adjust_market_buy_amount(amount, amount, price, self.fee_rate, self.fee_exponent, builder_taker_fee_rate)
-        platform_fee = calculate_platform_fee(adjusted, price, self.fee_rate, self.fee_exponent)
-        builder_fee = calculate_builder_fee(adjusted, builder_taker_fee_rate)
-        self.assertAlmostEqual(adjusted + platform_fee + builder_fee, amount, places=9)
+        adjusted = adjust_buy_amount_for_fees(amount, price, amount, 0, 0, builder_taker_fee_rate)
+        original_fee = calculate_builder_fee(amount, builder_taker_fee_rate)
+        adjusted_fee = calculate_builder_fee(adjusted, builder_taker_fee_rate)
+        self.assertEqual(original_fee, 0.5)
+        self.assertEqual(adjusted, 49.5)
+        self.assertEqual(adjusted_fee, 0.495)
+        self.assertEqual(adjusted + adjusted_fee, 49.995)
+
+    def test_platform_and_builder_fee_reserves_original_fees(self):
+        amount = 50
+        price = 0.5
+        builder_taker_fee_rate = 0.01
+        adjusted = adjust_buy_amount_for_fees(amount, price, amount, self.fee_rate, self.fee_exponent, builder_taker_fee_rate)
+        original_platform_fee = calculate_platform_fee(amount, price, self.fee_rate, self.fee_exponent)
+        original_builder_fee = calculate_builder_fee(amount, builder_taker_fee_rate)
+        adjusted_platform_fee = calculate_platform_fee(adjusted, price, self.fee_rate, self.fee_exponent)
+        adjusted_builder_fee = calculate_builder_fee(adjusted, builder_taker_fee_rate)
+        self.assertEqual(original_platform_fee, 1.5625)
+        self.assertEqual(original_builder_fee, 0.5)
+        self.assertEqual(adjusted, 47.9375)
+        self.assertEqual(adjusted_platform_fee, 1.498046875)
+        self.assertEqual(adjusted_builder_fee, 0.479375)
+        self.assertEqual(adjusted + adjusted_platform_fee + adjusted_builder_fee, 49.914921875)
 
     def test_adjusted_less_than_original(self):
         amount = 50
-        adjusted = adjust_market_buy_amount(amount, amount, 0.5, self.fee_rate, self.fee_exponent, 0)
-        self.assertLess(adjusted, amount)
+        adjusted = adjust_buy_amount_for_fees(amount, 0.5, amount, self.fee_rate, self.fee_exponent, 0)
+        self.assertEqual(adjusted, 48.4375)
 
-    def test_price_0_3_platform_and_builder_adjusted_plus_fees_equals_amount(self):
+    def test_price_0_3_platform_and_builder_reserves_original_fees(self):
         amount = 30
         price = 0.3
         builder_taker_fee_rate = 0.02
-        adjusted = adjust_market_buy_amount(amount, amount, price, self.fee_rate, self.fee_exponent, builder_taker_fee_rate)
-        platform_fee = calculate_platform_fee(adjusted, price, self.fee_rate, self.fee_exponent)
-        builder_fee = calculate_builder_fee(adjusted, builder_taker_fee_rate)
-        self.assertAlmostEqual(adjusted + platform_fee + builder_fee, amount, places=9)
+        adjusted = adjust_buy_amount_for_fees(amount, price, amount, self.fee_rate, self.fee_exponent, builder_taker_fee_rate)
+        original_platform_fee = calculate_platform_fee(amount, price, self.fee_rate, self.fee_exponent)
+        original_builder_fee = calculate_builder_fee(amount, builder_taker_fee_rate)
+        adjusted_platform_fee = calculate_platform_fee(adjusted, price, self.fee_rate, self.fee_exponent)
+        adjusted_builder_fee = calculate_builder_fee(adjusted, builder_taker_fee_rate)
+        self.assertEqual(round_to(original_platform_fee), 1.1025)
+        self.assertEqual(original_builder_fee, 0.6)
+        self.assertEqual(adjusted, 28.2975)
+        self.assertEqual(round_to(adjusted_platform_fee), 1.039933125)
+        self.assertEqual(adjusted_builder_fee, 0.56595)
+        self.assertEqual(round_to(adjusted + adjusted_platform_fee + adjusted_builder_fee), 29.903383125)
+
+    def test_uses_balance_as_fee_base_when_amount_exceeds_balance(self):
+        # amount > balance: feeBaseAmount = min(amount, balance) = balance
+        amount = 100
+        price = 0.3
+        user_usdc_balance = 1
+        rate = 0.072
+        exponent = 1
+        adjusted = adjust_buy_amount_for_fees(amount, price, user_usdc_balance, rate, exponent, 0)
+        reserved_fee = calculate_platform_fee(user_usdc_balance, price, rate, exponent)
+        adjusted_fee = calculate_platform_fee(adjusted, price, rate, exponent)
+        self.assertEqual(round_to(reserved_fee), 0.0504)
+        self.assertEqual(adjusted, 0.9496)
+        self.assertEqual(round_to(adjusted_fee), 0.04785984)
+        self.assertEqual(round_to(adjusted + adjusted_fee), 0.99745984)
+
+
+class TestFeeSlippage(unittest.TestCase):
+    fee_rate = 0.25
+    fee_exponent = 2
+
+    def test_pads_only_platform_fee_by_percentage(self):
+        amount = 50
+        price = 0.5
+        builder_taker_fee_rate = 0.01
+        fee_slippage = 20
+        adjusted = adjust_buy_amount_for_fees(amount, price, amount, self.fee_rate, self.fee_exponent, builder_taker_fee_rate, fee_slippage)
+        original_platform_fee = calculate_platform_fee(amount, price, self.fee_rate, self.fee_exponent, fee_slippage)
+        original_builder_fee = calculate_builder_fee(amount, builder_taker_fee_rate)
+        adjusted_platform_fee = calculate_platform_fee(adjusted, price, self.fee_rate, self.fee_exponent, fee_slippage)
+        adjusted_builder_fee = calculate_builder_fee(adjusted, builder_taker_fee_rate)
+        self.assertEqual(original_platform_fee, 1.875)
+        self.assertEqual(original_builder_fee, 0.5)
+        self.assertEqual(adjusted, 47.625)
+        self.assertEqual(adjusted_platform_fee, 1.7859375)
+        self.assertEqual(adjusted_builder_fee, 0.47625)
+        self.assertEqual(adjusted + adjusted_platform_fee + adjusted_builder_fee, 49.8871875)
+
+    def test_adjusts_when_balance_covers_unpadded_but_not_padded_fees(self):
+        amount = 50
+        price = 0.5
+        platform_fee = calculate_platform_fee(amount, price, self.fee_rate, self.fee_exponent)
+        padded_platform_fee = calculate_platform_fee(amount, price, self.fee_rate, self.fee_exponent, 20)
+        balance = amount + platform_fee + (padded_platform_fee - platform_fee) / 2
+
+        adjusted = adjust_buy_amount_for_fees(amount, price, balance, self.fee_rate, self.fee_exponent, 0, 20)
+
+        self.assertEqual(platform_fee, 1.5625)
+        self.assertEqual(padded_platform_fee, 1.875)
+        self.assertEqual(balance, 51.71875)
+        self.assertEqual(adjusted, 49.84375)
+
+    def test_accepts_float_percentages_between_1_and_100(self):
+        amount = 50
+        price = 0.5
+        adjusted = adjust_buy_amount_for_fees(amount, price, amount, self.fee_rate, self.fee_exponent, 0, 1.5)
+        original_platform_fee = calculate_platform_fee(amount, price, self.fee_rate, self.fee_exponent, 1.5)
+        adjusted_platform_fee = calculate_platform_fee(adjusted, price, self.fee_rate, self.fee_exponent, 1.5)
+
+        self.assertEqual(round_to(original_platform_fee), 1.5859375)
+        self.assertEqual(adjusted, 48.4140625)
+        self.assertEqual(round_to(adjusted_platform_fee), 1.535633544922)
+        self.assertEqual(round_to(adjusted + adjusted_platform_fee), 49.949696044922)
+
+    def test_rejects_fractional_below_1_and_values_over_100(self):
+        with self.assertRaises(ValueError) as ctx:
+            adjust_buy_amount_for_fees(50, 0.5, 50, self.fee_rate, self.fee_exponent, 0, 0.5)
+        self.assertIn("fee_slippage must be 0 or a percentage between 1 and 100", str(ctx.exception))
+
+        with self.assertRaises(ValueError) as ctx:
+            adjust_buy_amount_for_fees(50, 0.5, 50, self.fee_rate, self.fee_exponent, 0, 101)
+        self.assertIn("fee_slippage must be 0 or a percentage between 1 and 100", str(ctx.exception))
+
+
+class TestValidateFeeSlippage(unittest.TestCase):
+    def test_accepts_zero(self):
+        validate_fee_slippage(0)  # no exception
+
+    def test_accepts_100(self):
+        validate_fee_slippage(100)  # no exception
+
+    def test_accepts_float_between_1_and_100(self):
+        validate_fee_slippage(12.5)  # no exception
+        validate_fee_slippage(1.0)
+        validate_fee_slippage(99.9)
+
+    def test_rejects_below_1_but_above_0(self):
+        with self.assertRaises(ValueError):
+            validate_fee_slippage(0.5)
+
+    def test_rejects_above_100(self):
+        with self.assertRaises(ValueError):
+            validate_fee_slippage(101)
+
+    def test_rejects_negative(self):
+        with self.assertRaises(ValueError):
+            validate_fee_slippage(-1)
+
+    def test_rejects_nan(self):
+        with self.assertRaises(ValueError):
+            validate_fee_slippage(float("nan"))
+
+    def test_rejects_inf(self):
+        with self.assertRaises(ValueError):
+            validate_fee_slippage(float("inf"))
 
 
 class TestProductionFeeRatesV2(unittest.TestCase):
     amount = 100
 
     def test_sports_v2_rate_0_03_exp_1_price_0_5(self):
-        self.assertAlmostEqual(calculate_platform_fee(self.amount, 0.5, 0.03, 1), 1.5, delta=1e-6)
+        self.assertEqual(calculate_platform_fee(self.amount, 0.5, 0.03, 1), 1.5)
 
     def test_sports_v2_rate_0_03_exp_1_price_0_3(self):
-        self.assertAlmostEqual(calculate_platform_fee(self.amount, 0.3, 0.03, 1), 2.1, delta=1e-6)
+        self.assertEqual(round_to(calculate_platform_fee(self.amount, 0.3, 0.03, 1)), 2.1)
 
     def test_sports_v2_rate_0_03_exp_1_price_0_7(self):
-        self.assertAlmostEqual(calculate_platform_fee(self.amount, 0.7, 0.03, 1), 0.9, delta=1e-6)
+        self.assertEqual(round_to(calculate_platform_fee(self.amount, 0.7, 0.03, 1)), 0.9)
 
     def test_politics_rate_0_04_exp_1_price_0_5(self):
-        self.assertAlmostEqual(calculate_platform_fee(self.amount, 0.5, 0.04, 1), 2.0, delta=1e-6)
+        self.assertEqual(calculate_platform_fee(self.amount, 0.5, 0.04, 1), 2.0)
 
     def test_politics_rate_0_04_exp_1_price_0_3(self):
-        self.assertAlmostEqual(calculate_platform_fee(self.amount, 0.3, 0.04, 1), 2.8, delta=1e-6)
+        self.assertEqual(round_to(calculate_platform_fee(self.amount, 0.3, 0.04, 1)), 2.8)
 
     def test_politics_rate_0_04_exp_1_price_0_7(self):
-        self.assertAlmostEqual(calculate_platform_fee(self.amount, 0.7, 0.04, 1), 1.2, delta=1e-6)
+        self.assertEqual(round_to(calculate_platform_fee(self.amount, 0.7, 0.04, 1)), 1.2)
 
     def test_culture_rate_0_05_exp_1_price_0_5(self):
-        self.assertAlmostEqual(calculate_platform_fee(self.amount, 0.5, 0.05, 1), 2.5, delta=1e-6)
+        self.assertEqual(calculate_platform_fee(self.amount, 0.5, 0.05, 1), 2.5)
 
     def test_culture_rate_0_05_exp_1_price_0_3(self):
-        self.assertAlmostEqual(calculate_platform_fee(self.amount, 0.3, 0.05, 1), 3.5, delta=1e-6)
+        self.assertEqual(round_to(calculate_platform_fee(self.amount, 0.3, 0.05, 1)), 3.5)
 
     def test_culture_rate_0_05_exp_1_price_0_7(self):
-        self.assertAlmostEqual(calculate_platform_fee(self.amount, 0.7, 0.05, 1), 1.5, delta=1e-6)
+        self.assertEqual(round_to(calculate_platform_fee(self.amount, 0.7, 0.05, 1)), 1.5)
 
     def test_crypto_rate_0_072_exp_1_price_0_5(self):
-        self.assertAlmostEqual(calculate_platform_fee(self.amount, 0.5, 0.072, 1), 3.6, delta=1e-6)
+        self.assertEqual(round_to(calculate_platform_fee(self.amount, 0.5, 0.072, 1)), 3.6)
 
     def test_crypto_rate_0_072_exp_1_price_0_3(self):
-        self.assertAlmostEqual(calculate_platform_fee(self.amount, 0.3, 0.072, 1), 5.04, delta=1e-6)
+        self.assertEqual(calculate_platform_fee(self.amount, 0.3, 0.072, 1), 5.04)
 
     def test_crypto_rate_0_072_exp_1_price_0_7(self):
-        self.assertAlmostEqual(calculate_platform_fee(self.amount, 0.7, 0.072, 1), 2.16, delta=1e-6)
+        self.assertEqual(calculate_platform_fee(self.amount, 0.7, 0.072, 1), 2.16)
 
-    def test_balance_adjusted_plus_fee_equals_amount_all_rates(self):
+    def test_balance_equals_amount_reserves_original_fee(self):
         cases = [
-            (0.03, 1, 0.3), (0.03, 1, 0.5), (0.03, 1, 0.7),
-            (0.04, 1, 0.3), (0.04, 1, 0.5), (0.04, 1, 0.7),
-            (0.05, 1, 0.3), (0.05, 1, 0.5), (0.05, 1, 0.7),
-            (0.072, 1, 0.3), (0.072, 1, 0.5), (0.072, 1, 0.7),
+            ("sports_fees_v2", 0.03, 1, {
+                0.3: {"original_fee": 2.1, "adjusted": 97.9, "adjusted_fee": 2.0559, "final": 99.9559},
+                0.5: {"original_fee": 1.5, "adjusted": 98.5, "adjusted_fee": 1.4775, "final": 99.9775},
+                0.7: {"original_fee": 0.9, "adjusted": 99.1, "adjusted_fee": 0.8919, "final": 99.9919},
+            }),
+            ("politics_fees", 0.04, 1, {
+                0.3: {"original_fee": 2.8, "adjusted": 97.2, "adjusted_fee": 2.7216, "final": 99.9216},
+                0.5: {"original_fee": 2.0, "adjusted": 98.0, "adjusted_fee": 1.96, "final": 99.96},
+                0.7: {"original_fee": 1.2, "adjusted": 98.8, "adjusted_fee": 1.1856, "final": 99.9856},
+            }),
+            ("culture_fees", 0.05, 1, {
+                0.3: {"original_fee": 3.5, "adjusted": 96.5, "adjusted_fee": 3.3775, "final": 99.8775},
+                0.5: {"original_fee": 2.5, "adjusted": 97.5, "adjusted_fee": 2.4375, "final": 99.9375},
+                0.7: {"original_fee": 1.5, "adjusted": 98.5, "adjusted_fee": 1.4775, "final": 99.9775},
+            }),
+            ("crypto_fees_v2", 0.072, 1, {
+                0.3: {"original_fee": 5.04, "adjusted": 94.96, "adjusted_fee": 4.785984, "final": 99.745984},
+                0.5: {"original_fee": 3.6, "adjusted": 96.4, "adjusted_fee": 3.4704, "final": 99.8704},
+                0.7: {"original_fee": 2.16, "adjusted": 97.84, "adjusted_fee": 2.113344, "final": 99.953344},
+            }),
         ]
-        for rate, exponent, price in cases:
-            with self.subTest(rate=rate, exponent=exponent, price=price):
-                amount = 100
-                adjusted = adjust_market_buy_amount(amount, amount, price, rate, exponent, 0)
-                fee = calculate_platform_fee(adjusted, price, rate, exponent)
-                self.assertAlmostEqual(adjusted + fee, amount, places=9)
+        amount = 100
+        for name, rate, exponent, expected_by_price in cases:
+            for price in [0.3, 0.5, 0.7]:
+                exp = expected_by_price[price]
+                with self.subTest(name=name, price=price):
+                    adjusted = adjust_buy_amount_for_fees(amount, price, amount, rate, exponent, 0)
+                    original_fee = calculate_platform_fee(amount, price, rate, exponent)
+                    adjusted_fee = calculate_platform_fee(adjusted, price, rate, exponent)
+                    self.assertEqual(round_to(original_fee), exp["original_fee"])
+                    self.assertEqual(round_to(adjusted), exp["adjusted"])
+                    self.assertEqual(round_to(adjusted_fee), exp["adjusted_fee"])
+                    self.assertEqual(round_to(adjusted + adjusted_fee), exp["final"])

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -227,7 +227,7 @@ class TestUtilities(TestCase):
         self.assertEqual(result, 10.0)
 
     def test_adjust_market_buy_amount_platform_fee_only(self):
-        # invariant: effective + platform_fee == budget (within 1e-10)
+        # invariant: adjusted = balance - reserved_fee where reserved_fee uses original amount
         budget = 50.0
         price = 0.5
         fee_rate = 0.25
@@ -240,11 +240,11 @@ class TestUtilities(TestCase):
             fee_exponent=fee_exponent,
         )
         platform_fee_rate = fee_rate * (price * (1 - price)) ** fee_exponent
-        platform_fee = (effective / price) * platform_fee_rate
-        self.assertAlmostEqual(effective + platform_fee, budget, delta=1e-10)
+        reserved_fee = (budget / price) * platform_fee_rate  # fee based on balance (feeBaseAmount = min(100, 50) = 50)
+        self.assertAlmostEqual(effective, budget - reserved_fee, delta=1e-10)
 
     def test_adjust_market_buy_amount_builder_fee_only(self):
-        # invariant: effective + builder_fee == budget (within 1e-10)
+        # invariant: adjusted = balance - reserved_builder_fee
         budget = 50.0
         price = 0.5
         builder_taker_fee_rate = 0.01
@@ -256,11 +256,11 @@ class TestUtilities(TestCase):
             fee_exponent=0,
             builder_taker_fee_rate=builder_taker_fee_rate,
         )
-        builder_fee = effective * builder_taker_fee_rate
-        self.assertAlmostEqual(effective + builder_fee, budget, delta=1e-10)
+        reserved_builder_fee = budget * builder_taker_fee_rate
+        self.assertAlmostEqual(effective, budget - reserved_builder_fee, delta=1e-10)
 
     def test_adjust_market_buy_amount_combined_fees(self):
-        # invariant: effective + platform_fee + builder_fee == budget (within 1e-10)
+        # invariant: adjusted = balance - reserved_platform_fee - reserved_builder_fee
         budget = 50.0
         price = 0.5
         fee_rate = 0.25
@@ -275,12 +275,12 @@ class TestUtilities(TestCase):
             builder_taker_fee_rate=builder_taker_fee_rate,
         )
         platform_fee_rate = fee_rate * (price * (1 - price)) ** fee_exponent
-        platform_fee = (effective / price) * platform_fee_rate
-        builder_fee = effective * builder_taker_fee_rate
-        self.assertAlmostEqual(effective + platform_fee + builder_fee, budget, delta=1e-10)
+        reserved_platform_fee = (budget / price) * platform_fee_rate
+        reserved_builder_fee = budget * builder_taker_fee_rate
+        self.assertAlmostEqual(effective, budget - reserved_platform_fee - reserved_builder_fee, delta=1e-10)
 
     def test_adjust_market_buy_amount_price_near_boundary(self):
-        # price near minimum tick (0.0001) — pfr/price quotient is large, float errors compound
+        # price near minimum tick (0.0001) — feeBaseAmount = min(100, 50) = 50 = balance
         budget = 50.0
         price = 0.0001
         fee_rate = 0.25
@@ -295,9 +295,9 @@ class TestUtilities(TestCase):
             builder_taker_fee_rate=builder_taker_fee_rate,
         )
         platform_fee_rate = fee_rate * (price * (1 - price)) ** fee_exponent
-        platform_fee = (effective / price) * platform_fee_rate
-        builder_fee = effective * builder_taker_fee_rate
-        self.assertAlmostEqual(effective + platform_fee + builder_fee, budget, delta=1e-10)
+        reserved_platform_fee = (budget / price) * platform_fee_rate
+        reserved_builder_fee = budget * builder_taker_fee_rate
+        self.assertAlmostEqual(effective, budget - reserved_platform_fee - reserved_builder_fee, delta=1e-10)
 
     def test_adjust_market_buy_amount_exactly_at_limit(self):
         # balance == total_cost triggers the adjustment path


### PR DESCRIPTION
## Summary
- add fee slippage validation and buy amount adjustment helpers
- thread fee slippage through CLOB order creation for adjusted buy sizing
- add coverage for fee calculation and client order adjustment behavior

## Verification
- git diff --check origin/main...HEAD
- python3 -m pytest (blocked: pytest was not installed; installing requirements was blocked because poly_eip712_structs==0.0.1 was unavailable from the configured package index)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how buy order size/amount is computed against USDC balance and fees, which directly affects submitted order amounts; behavior is heavily tested but is trading-critical.
> 
> **Overview**
> Adds **`fee_slippage`** on `ClobClient` (0 or 1–100%, validated at init) and centralizes buy-side fee math in **`adjust_buy_amount_for_fees`**, which pads the platform fee rate by slippage and, when collateral is tight, shrinks the buy notional by reserving fees computed from `min(amount, balance)` rather than the previous balance-fitting formula.
> 
> **V2 limit buys** can pass **`user_usdc_balance`** on `OrderArgsV2`; `create_order` rounds price to tick, adjusts notional/size via the shared helper (including builder taker fees), and builds from a `dataclass_replace` copy so caller args stay unchanged. **Market buys** use the same path instead of inlined fee logic.
> 
> `adjust_market_buy_amount` now delegates to the new helper (exported from the package). Tests were rewritten for the new “reserve original fee” semantics and for client-signed order amounts with slippage. Release version **1.0.1**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3d1b057316f07b706aaa1505950e4030e29cf08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->