### PR TITLE
fix: support new tick sizes

### DIFF
--- a/py_clob_client_v2/clob_types.py
+++ b/py_clob_client_v2/clob_types.py
@@ -253,7 +253,7 @@ class OrderPayload:
     orderID: str
 
 
-TickSize = Literal["0.1", "0.01", "0.001", "0.0001"]
+TickSize = Literal["0.1", "0.01", "0.005", "0.0025", "0.001", "0.0001"]
 
 
 @dataclass

--- a/py_clob_client_v2/order_builder/builder.py
+++ b/py_clob_client_v2/order_builder/builder.py
@@ -36,6 +36,8 @@ from ..order_utils.model.order_data_v2 import OrderDataV2, SignedOrderV2
 ROUNDING_CONFIG: dict = {
     "0.1":    RoundConfig(price=1, size=2, amount=3),
     "0.01":   RoundConfig(price=2, size=2, amount=4),
+    "0.005":  RoundConfig(price=3, size=2, amount=5),
+    "0.0025": RoundConfig(price=4, size=2, amount=6),
     "0.001":  RoundConfig(price=3, size=2, amount=5),
     "0.0001": RoundConfig(price=4, size=2, amount=6),
 }

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -186,7 +186,14 @@ class TestUtilities(TestCase):
             self.assertNotIn("nonce", o)
 
     def test_order_to_json_v2_neg_risk(self):
-        for tick_size, price in [("0.1", 0.5), ("0.01", 0.56), ("0.001", 0.056), ("0.0001", 0.0056)]:
+        for tick_size, price in [
+            ("0.1", 0.5),
+            ("0.01", 0.56),
+            ("0.005", 0.555),
+            ("0.0025", 0.5525),
+            ("0.001", 0.056),
+            ("0.0001", 0.0056),
+        ]:
             for side in [BUY, SELL]:
                 order = builder.build_order(
                     OrderArgsV2(token_id=TOKEN_ID, price=price, size=10, side=side),


### PR DESCRIPTION
## Summary
- add 0.005 and 0.0025 to the TickSize literal
- add matching order builder rounding config entries
- extend existing order serialization coverage for the new tick sizes

## Verification
- git diff --check
- python3 -m compileall py_clob_client_v2 tests/test_utilities.py
- uv run --with-requirements requirements.txt pytest tests/test_utilities.py
- uv run --with-requirements requirements.txt pytest tests/order_builder/test_builder.py

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tick-size rounding drives on-chain maker/taker amounts; misconfiguration could reject or mis-price orders, though the change mirrors established config for adjacent ticks.
> 
> **Overview**
> Adds **`0.005`** and **`0.0025`** as supported market tick sizes so clients can build and serialize orders when markets use those finer price grids.
> 
> The `TickSize` literal in `clob_types.py` is extended, and `OrderBuilder`’s `ROUNDING_CONFIG` gains matching entries (price rounding aligned with the existing `0.001` / `0.0001` precision pattern). Neg-risk V2 `order_to_json_v2` tests now cover both new tick sizes alongside the existing ones.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f662f4572d04d6b1a28998774fade5bfd8bb5edc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->