### PR TITLE
version: 1.0.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="py_clob_client_v2",
-    version="1.0.1",
+    version="1.0.2",
     author="Polymarket Engineering",
     author_email="engineering@polymarket.com",
     maintainer="Polymarket Engineering",


### PR DESCRIPTION
## Summary
- Bump package version to 1.0.2 for the new tick-size release.

## Verification
- git diff --check
- python3 -m compileall py_clob_client_v2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata version bump with no code or dependency changes in the diff.
> 
> **Overview**
> Bumps the published package version in `setup.py` from **1.0.1** to **1.0.2** to tag the tick-size release described in the PR notes.
> 
> No runtime, API, or dependency changes appear in this diff—only the version string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cba69a24c6a09c6f0ef5aef33ec06eec36e0cdd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->