### PR TITLE
fix(signing): serialize non-string HMAC bodies with json.dumps (#108)

### DIFF
--- a/py_clob_client_v2/signing/hmac.py
+++ b/py_clob_client_v2/signing/hmac.py
@@ -1,6 +1,7 @@
 import hmac
 import hashlib
 import base64
+import json
 
 
 def build_hmac_signature(
@@ -13,8 +14,14 @@ def build_hmac_signature(
     base64_secret = base64.urlsafe_b64decode(secret)
     message = str(timestamp) + str(method) + str(requestPath)
     if body:
-        # Match the canonical API signing payload format.
-        message += str(body).replace("'", '"')
+        # A pre-serialized string body is signed verbatim so it matches the exact
+        # bytes sent on the wire. Structured bodies are serialized with json.dumps
+        # so Python values like False/None become JSON false/null (str() would emit
+        # "False"/"None", producing a signature that mismatches the sent payload).
+        if isinstance(body, str):
+            message += body
+        else:
+            message += json.dumps(body, ensure_ascii=False)
 
     # nosec: SHA256 is used here for API request signing (HMAC-SHA256), not password hashing
     h = hmac.new(base64_secret, bytes(message, "utf-8"), hashlib.sha256)

--- a/tests/signing/test_hmac.py
+++ b/tests/signing/test_hmac.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 import binascii
+import json
 
 from py_clob_client_v2.signing.hmac import build_hmac_signature
 
@@ -174,3 +175,40 @@ class TestHMAC(TestCase):
             self.secret, self.timestamp, self.method, self.path, '{"x":1,"y":2}'
         )
         self.assertNotEqual(sig_a, sig_b)
+
+    def _sig(self, body):
+        return build_hmac_signature(
+            self.secret, self.timestamp, self.method, self.path, body
+        )
+
+    def test_bool_value_serialized_as_json_not_python_repr(self):
+        # Regression for #108: str({"deferExec": False}) yields "False", not the
+        # JSON "false" the server actually receives. The signature must be taken
+        # over the json.dumps form so it matches the sent payload.
+        body = {"deferExec": False}
+        self.assertEqual(
+            self._sig(body), self._sig(json.dumps(body, ensure_ascii=False))
+        )
+        # The broken str()-based rendering must NOT match the fixed signature.
+        self.assertNotEqual(self._sig(body), self._sig(str(body).replace("'", '"')))
+        # Explicitly: signing the dict matches signing '{"deferExec": false}'.
+        self.assertEqual(self._sig(body), self._sig('{"deferExec": false}'))
+
+    def test_none_value_serialized_as_json_null(self):
+        # Regression for #108: str({"foo": None}) yields "None", not JSON "null".
+        body = {"foo": None}
+        self.assertEqual(
+            self._sig(body), self._sig(json.dumps(body, ensure_ascii=False))
+        )
+        self.assertNotEqual(self._sig(body), self._sig(str(body).replace("'", '"')))
+        self.assertEqual(self._sig(body), self._sig('{"foo": null}'))
+
+    def test_bool_true_and_nested_none_serialized_as_json(self):
+        body = {"a": True, "b": {"c": None}, "d": [False, None]}
+        self.assertEqual(
+            self._sig(body), self._sig(json.dumps(body, ensure_ascii=False))
+        )
+        self.assertEqual(
+            self._sig(body),
+            self._sig('{"a": true, "b": {"c": null}, "d": [false, null]}'),
+        )


### PR DESCRIPTION
## Problem

`build_hmac_signature` serialized non-string bodies with `str(body).replace("'", '"')`. That matches JSON for string-only dicts, but Python `False`/`None` render as `False`/`None` instead of JSON `false`/`null`. Signing `{"deferExec": False}` produces an HMAC over `{"deferExec": False}` while the payload actually sent to the server is `{"deferExec": false}` — so the signature is invalid.

Internal callers avoid this by passing `serialized_body` (compact `json.dumps`), which `create_level_2_headers` prefers. But `build_hmac_signature` is exported and the header builder falls back to the dict `body` when `serialized_body` is omitted, so external/manual callers on the dict path get a broken signature.

Fixes #108.

## Fix

`py_clob_client_v2/signing/hmac.py`:
- Non-string bodies → `json.dumps(body, ensure_ascii=False)`, so `False`/`None` become `false`/`null`.
- Pre-serialized string bodies are signed **verbatim** (removing the obsolete `.replace("'", '"')` hack, which only existed to convert Python dict repr to JSON and could corrupt strings containing apostrophes).

Backward compatibility: for string-only dicts, `json.dumps` with default separators produces the same bytes as the old `str(dict).replace(...)` form (e.g. `{"hash": "0x123"}`), so previously valid signatures are unchanged. The existing pinned baseline signature test still passes.

## Tests

Added regression tests in `tests/signing/test_hmac.py` covering boolean, `None`, and nested bool/null dict values — each asserts the signature equals the `json.dumps` form and the explicit JSON literal (e.g. `{"deferExec": false}`), and does **not** equal the old broken `str()`-based rendering.

Full suite: **230 passed** (22 in `test_hmac.py`). `hmac.py` passes `black --check`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request-signing payload canonicalization; wrong serialization would break authenticated API calls, though string-only dicts stay compatible and tests cover the regression.
> 
> **Overview**
> Fixes **invalid API HMAC signatures** when callers pass a dict body containing `False`, `None`, or other non-JSON-literal Python values.
> 
> `build_hmac_signature` no longer builds the signed message from `str(body).replace("'", '"')`. **String bodies** are appended verbatim; **structured bodies** use `json.dumps(..., ensure_ascii=False)` so the signed bytes match JSON on the wire (`false`/`null`, not `False`/`None`). That aligns signing with the dict fallback path in `create_level_2_headers` when `serialized_body` is omitted.
> 
> Regression tests assert dict signing matches explicit JSON literals and no longer matches the old `str()`-based payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a1d78743554bf957efbe1c2f6aad9261c277d67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->