### PR TITLE
Clarify get_fee_rate_bps semantics; add get_fee_rate for the real per-market rate (#107)

### DIFF
--- a/py_clob_client_v2/client.py
+++ b/py_clob_client_v2/client.py
@@ -383,6 +383,18 @@ class ClobClient:
         return self.__neg_risk[token_id]
 
     def get_fee_rate_bps(self, token_id: str) -> int:
+        """Return the ``base_fee`` value from ``GET /fee-rate`` for ``token_id``.
+
+        This is the fee-authorization value that gets signed into the
+        ``feeRateBps`` field of v1 orders (see ``__resolve_fee_rate_bps``); it is
+        the maximum fee rate the operator is permitted to charge, capped
+        on-chain by the exchange's global max fee rate. It is a constant
+        (currently ``1000`` bps for every fee-bearing market, ``0`` for fee-free
+        markets) and is **not** the effective per-market rate: the fee actually
+        charged is computed from the per-category rate. Use
+        :meth:`get_fee_rate` for that real rate, or
+        :meth:`get_fee_exponent`/the fee helpers to estimate the charged fee.
+        """
         if token_id in self.__fee_rates:
             return self.__fee_rates[token_id]
 
@@ -391,6 +403,19 @@ class ClobClient:
         )
         self.__fee_rates[token_id] = result.get("base_fee") or 0
         return self.__fee_rates[token_id]
+
+    def get_fee_rate(self, token_id: str) -> float:
+        """Return the real per-market fee rate (``fd.r``) for ``token_id``.
+
+        Unlike :meth:`get_fee_rate_bps`, this is the effective per-category rate
+        the charged fee is derived from (e.g. ``0.07`` for a Crypto market),
+        expressed as a fraction. Fetched from the market's ``fd`` block on
+        ``GET /clob-markets/{condition_id}``.
+        """
+        if token_id in self.__fee_infos:
+            return self.__fee_infos[token_id].rate
+        self.__ensure_market_info_cached(token_id)
+        return self.__fee_infos[token_id].rate
 
     def get_fee_exponent(self, token_id: str) -> float:
         if token_id in self.__fee_infos:

--- a/tests/test_client_fee_cache.py
+++ b/tests/test_client_fee_cache.py
@@ -80,6 +80,48 @@ class TestGetFeeRateBps(TestCase):
         self.assertEqual(rate, 0)
 
 
+class TestGetFeeRate(TestCase):
+    def test_returns_cached_rate_from_market_info(self):
+        client = _make_client()
+        _inject_market_info(client, TOKEN_ID, rate=0.07, exponent=1.0)
+        self.assertEqual(client.get_fee_rate(TOKEN_ID), 0.07)
+
+    def test_fetches_market_info_when_not_cached(self):
+        client = _make_client()
+        client._ClobClient__token_condition_map[TOKEN_ID] = CONDITION_ID
+
+        clob_market_response = {
+            "t": [{"t": TOKEN_ID}],
+            "mts": "0.01",
+            "nr": False,
+            "fd": {"r": 0.04, "e": 1.0},
+        }
+        with patch.object(client, "_get", return_value=clob_market_response):
+            rate = client.get_fee_rate(TOKEN_ID)
+
+        self.assertEqual(rate, 0.04)
+
+    def test_no_refetch_after_cache_hit(self):
+        client = _make_client()
+        _inject_market_info(client, TOKEN_ID, rate=0.05, exponent=1.0)
+
+        with patch.object(client, "_get") as mock_get:
+            rate = client.get_fee_rate(TOKEN_ID)
+
+        self.assertEqual(rate, 0.05)
+        mock_get.assert_not_called()
+
+    def test_is_not_the_fee_rate_bps_endpoint_value(self):
+        """get_fee_rate exposes the real per-market rate, distinct from the
+        constant base_fee flag returned by get_fee_rate_bps."""
+        client = _make_client()
+        _inject_market_info(client, TOKEN_ID, rate=0.07, exponent=1.0)
+        with patch.object(client, "_get", return_value={"base_fee": 1000}):
+            base_fee = client.get_fee_rate_bps(TOKEN_ID)
+        self.assertEqual(base_fee, 1000)
+        self.assertEqual(client.get_fee_rate(TOKEN_ID), 0.07)
+
+
 class TestGetFeeExponent(TestCase):
     def test_returns_cached_exponent_from_market_info(self):
         client = _make_client()


### PR DESCRIPTION
## Summary

Addresses the SDK-observable half of Polymarket/py-clob-client-v2#107.

`get_fee_rate_bps()` returns `/fee-rate`'s `base_fee`, which is a **constant** (`1000` bps for every fee-bearing market, `0` for fee-free) — it is the fee **authorization** value signed into v1 orders as `feeRateBps` (capped on-chain by the exchange's global max fee rate in `_validateFeeRate`), **not** the effective per-market rate. Integrators reading it as "the fee rate in bps" compute wrong fees (the reporter's core finding: `1000` never matched any market's real 400/500/700 bps).

The real per-category rate already lives in the SDK as `FeeInfo.rate` (`fd.r`), populated from `GET /clob-markets/{condition_id}` and used by the fee-estimation helpers — but there was no public getter for it (only `get_fee_exponent`).

## Changes
- Docstring on `get_fee_rate_bps()` documenting that `base_fee` is an authorization/ceiling value, not the effective rate, and pointing to the real one.
- New `get_fee_rate(token_id) -> float` returning the real per-market rate (`fd.r`), mirroring the existing `get_fee_exponent`.
- 4 tests in `TestGetFeeRate` (cache hit, lazy fetch, no-refetch, and distinctness from `get_fee_rate_bps`).

## What this deliberately does NOT change
The reporter asked (#107 Q2) whether `__resolve_fee_rate_bps()` should sign `fd.r` instead of `base_fee`. **No** — that would be a regression. The canonical TS SDK (`clob-client-v2`) signs `base_fee` identically, and the signed `feeRateBps` is a max-fee authorization the operator charges under, not the applied rate. Lowering it to `fd.r` would reduce the on-chain ceiling and diverge from the TS SDK / server expectations. Production trades daily with `base_fee=1000`, so it is the correct value to sign. This PR leaves signing untouched and only removes the ambiguity.

The remaining items in #107 (documenting `base_fee` as a flag in the public API reference, `fd.e` semantics, USDC-side vs share-side collection, and `fee_rate_bps: 0` on charged trade records) are backend/docs-owned and are being triaged separately.

## Test plan
- `pytest tests/test_client_fee_cache.py tests/test_fee_calculations.py` → 69 passed (public deps only; private `poly_eip712_structs` not required for these).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only API and documentation only; no changes to order signing or fee calculation paths.
> 
> **Overview**
> Clarifies that **`get_fee_rate_bps`** returns `/fee-rate`'s **`base_fee`**—the constant fee **authorization** signed into v1 orders—not the rate used to compute charged fees. The docstring directs integrators to the new API for the effective rate.
> 
> Adds **`get_fee_rate(token_id)`**, returning the per-market **`fd.r`** fraction (same cache path as **`get_fee_exponent`**). Order signing via **`__resolve_fee_rate_bps`** is unchanged.
> 
> Includes **`TestGetFeeRate`** coverage for cache behavior and distinction from **`get_fee_rate_bps`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e3bfc34b843e5b991f0c6fe298b389d80031db7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->