### PR TITLE
Rate Limit Tiers Endpoint

### DIFF
--- a/py_clob_client_v2/client.py
+++ b/py_clob_client_v2/client.py
@@ -102,6 +102,7 @@ from .endpoints import (
     POST_HEARTBEAT,
     POST_ORDER,
     POST_ORDERS,
+    RATE_LIMIT_TIER,
     REVOKE_BUILDER_API_KEY,
     TIME,
     TRADES,
@@ -524,6 +525,10 @@ class ClobClient:
         except Exception:
             pass
         return self.derive_api_key(nonce=nonce)
+
+    def get_rate_limit_tier(self):
+        headers = self._l2_headers("GET", RATE_LIMIT_TIER)
+        return self._get(f"{self.host}{RATE_LIMIT_TIER}", headers=headers)
 
     def get_api_keys(self):
         headers = self._l2_headers("GET", GET_API_KEYS)

--- a/py_clob_client_v2/endpoints.py
+++ b/py_clob_client_v2/endpoints.py
@@ -101,3 +101,6 @@ GET_RFQ_BEST_QUOTE = "/rfq/data/best-quote"
 RFQ_REQUESTS_ACCEPT = "/rfq/request/accept"
 RFQ_QUOTE_APPROVE = "/rfq/quote/approve"
 RFQ_CONFIG = "/rfq/config"
+
+# Rate Limit Tier Endpoint
+RATE_LIMIT_TIER = "/v1/user/rate-limit-tier"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small additive read-only API wrapper with no changes to trading, auth, or existing behavior.
> 
> **Overview**
> Adds **L2-authenticated** client support for querying the user’s API **rate limit tier** from `GET /v1/user/rate-limit-tier`.
> 
> `ClobClient.get_rate_limit_tier()` signs the request like other user endpoints (e.g. `get_api_keys`) and returns the raw API response. The path is exposed as `RATE_LIMIT_TIER` in `endpoints.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e2da0dd767272bcf5dd28e4178f09e9e1a01a1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->