### PR TITLE
perf: prewarm order metadata and reuse order hash

### DIFF
--- a/py_clob_client_v2/client.py
+++ b/py_clob_client_v2/client.py
@@ -353,7 +353,11 @@ class ClobClient:
             for token_id in token_ids:
                 self.get_fee_rate_bps(token_id)
 
-        if builder_code and builder_code != BYTES32_ZERO:
+        if (
+            builder_code
+            and builder_code != BYTES32_ZERO
+            and builder_code not in self.__builder_fee_rates
+        ):
             self.__load_builder_fee_rate(builder_code)
 
     def get_order_book(self, token_id: str):

--- a/py_clob_client_v2/client.py
+++ b/py_clob_client_v2/client.py
@@ -339,6 +339,23 @@ class ClobClient:
 
         return result
 
+    def warm_up_order_metadata(
+        self,
+        condition_id: str,
+        builder_code: Optional[str] = None,
+    ) -> None:
+        """Cache the public metadata needed to construct orders for a market."""
+        result = self.get_clob_market_info(condition_id)
+        version = self.__resolve_version()
+        token_ids = [token["t"] for token in result["t"] if token and token.get("t")]
+
+        if version == 1:
+            for token_id in token_ids:
+                self.get_fee_rate_bps(token_id)
+
+        if builder_code and builder_code != BYTES32_ZERO:
+            self.__load_builder_fee_rate(builder_code)
+
     def get_order_book(self, token_id: str):
         return self._get(
             f"{self.host}{GET_ORDER_BOOK}", params={"token_id": token_id}
@@ -1206,13 +1223,19 @@ class ClobClient:
         if builder_code in self.__builder_fee_rates:
             return
         try:
-            result = self._get(f"{self.host}{GET_BUILDER_FEE_RATE}{builder_code}")
-            self.__builder_fee_rates[builder_code] = BuilderFeeRate(
-                maker=result.get("builder_maker_fee_rate_bps", 0) / BUILDER_FEES_BPS,
-                taker=result.get("builder_taker_fee_rate_bps", 0) / BUILDER_FEES_BPS,
-            )
+            self.__load_builder_fee_rate(builder_code)
         except Exception:
-            logging.warning("failed to fetch builder fee rate for %s, will retry on next order", builder_code)
+            logging.warning(
+                "failed to fetch builder fee rate for %s, will retry on next order",
+                builder_code,
+            )
+
+    def __load_builder_fee_rate(self, builder_code: str) -> None:
+        result = self._get(f"{self.host}{GET_BUILDER_FEE_RATE}{builder_code}")
+        self.__builder_fee_rates[builder_code] = BuilderFeeRate(
+            maker=result.get("builder_maker_fee_rate_bps", 0) / BUILDER_FEES_BPS,
+            taker=result.get("builder_taker_fee_rate_bps", 0) / BUILDER_FEES_BPS,
+        )
 
     def __ensure_market_info_cached(self, token_id: str):
         if token_id in self.__fee_infos:

--- a/py_clob_client_v2/order_utils/exchange_order_builder_v1.py
+++ b/py_clob_client_v2/order_utils/exchange_order_builder_v1.py
@@ -36,8 +36,14 @@ class ExchangeOrderBuilderV1:
     def build_signed_order(self, order_data: OrderDataV1) -> SignedOrderV1:
         order = self.build_order(order_data)
         typed_data = self.build_order_typed_data(order)
-        signature = self.build_order_signature(typed_data)
-        return SignedOrderV1(**{**dataclasses.asdict(order), "signature": signature})
+        signature, order_hash = self._build_order_signature_and_hash(typed_data)
+        return SignedOrderV1(
+            **{
+                **dataclasses.asdict(order),
+                "signature": signature,
+                "order_hash": order_hash,
+            }
+        )
 
     def build_order(self, order_data: OrderDataV1) -> OrderV1:
         signer_addr = order_data.signer if order_data.signer else order_data.maker
@@ -94,9 +100,16 @@ class ExchangeOrderBuilderV1:
         }
 
     def build_order_signature(self, typed_data: dict) -> str:
+        signature, _ = self._build_order_signature_and_hash(typed_data)
+        return signature
+
+    def _build_order_signature_and_hash(self, typed_data: dict) -> tuple[str, str]:
         encoded = encode_typed_data(full_message=typed_data)
         signed = Account.sign_message(encoded, private_key=self.signer.private_key)
-        return "0x" + signed.signature.hex()
+        return (
+            "0x" + signed.signature.hex(),
+            "0x" + signed.message_hash.hex(),
+        )
 
     def build_order_hash(self, typed_data: dict) -> str:
         encoded = encode_typed_data(full_message=typed_data)

--- a/py_clob_client_v2/order_utils/exchange_order_builder_v2.py
+++ b/py_clob_client_v2/order_utils/exchange_order_builder_v2.py
@@ -86,8 +86,14 @@ class ExchangeOrderBuilderV2:
     def build_signed_order(self, order_data: OrderDataV2) -> SignedOrderV2:
         order = self.build_order(order_data)
         typed_data = self.build_order_typed_data(order)
-        signature = self.build_order_signature(typed_data)
-        return SignedOrderV2(**{**dataclasses.asdict(order), "signature": signature})
+        signature, order_hash = self._build_order_signature_and_hash(typed_data)
+        return SignedOrderV2(
+            **{
+                **dataclasses.asdict(order),
+                "signature": signature,
+                "order_hash": order_hash,
+            }
+        )
 
     def build_order(self, order_data: OrderDataV2) -> OrderV2:
         signer_addr = order_data.signer if order_data.signer else order_data.maker
@@ -157,6 +163,16 @@ class ExchangeOrderBuilderV2:
         encoded = encode_typed_data(full_message=typed_data)
         signed = Account.sign_message(encoded, private_key=self.signer.private_key)
         return "0x" + signed.signature.hex()
+
+    def _build_order_signature_and_hash(self, typed_data: dict) -> tuple[str, str]:
+        encoded = encode_typed_data(full_message=typed_data)
+
+        if typed_data["message"]["signatureType"] == int(SignatureTypeV2.POLY_1271):
+            order_hash = "0x" + _hash_message(encoded).hex()
+            return self._build_poly_1271_order_signature(typed_data), order_hash
+
+        signed = Account.sign_message(encoded, private_key=self.signer.private_key)
+        return "0x" + signed.signature.hex(), "0x" + signed.message_hash.hex()
 
     def _build_poly_1271_order_signature(self, typed_data: dict) -> str:
         message = typed_data["message"]

--- a/py_clob_client_v2/order_utils/model/order_data_v1.py
+++ b/py_clob_client_v2/order_utils/model/order_data_v1.py
@@ -45,6 +45,7 @@ class SignedOrderV1(OrderV1):
     """A signed V1 order including the EIP712 signature."""
 
     signature: str = ""
+    order_hash: str = ""
 
 
 def order_to_json_v1(

--- a/py_clob_client_v2/order_utils/model/order_data_v2.py
+++ b/py_clob_client_v2/order_utils/model/order_data_v2.py
@@ -45,6 +45,7 @@ class SignedOrderV2(OrderV2):
     """A signed V2 order including the EIP712 signature."""
 
     signature: str = ""
+    order_hash: str = ""
 
 
 def order_to_json_v2(

--- a/tests/order_utils/test_exchange_order_builder_v1.py
+++ b/tests/order_utils/test_exchange_order_builder_v1.py
@@ -1,9 +1,15 @@
 from unittest import TestCase
+from unittest.mock import patch
 
 from py_clob_client_v2.constants import AMOY, ZERO_ADDRESS
 from py_clob_client_v2.config import get_contract_config
-from py_clob_client_v2.order_utils.exchange_order_builder_v1 import ExchangeOrderBuilderV1
-from py_clob_client_v2.order_utils.model.order_data_v1 import OrderDataV1
+from py_clob_client_v2.order_utils.exchange_order_builder_v1 import (
+    ExchangeOrderBuilderV1,
+)
+from py_clob_client_v2.order_utils.model.order_data_v1 import (
+    OrderDataV1,
+    order_to_json_v1,
+)
 from py_clob_client_v2.order_utils.model.ctf_exchange_v1_typed_data import (
     CTF_EXCHANGE_V1_DOMAIN_NAME,
     CTF_EXCHANGE_V1_DOMAIN_VERSION,
@@ -35,6 +41,7 @@ _ORDER_DATA = OrderDataV1(
     expiration="0",
     signatureType=SignatureTypeV1.EOA,
 )
+
 
 class TestExchangeOrderBuilderV1CTF(TestCase):
     """Tests against the CTF Exchange (Polymarket CTF Exchange v1)."""
@@ -206,6 +213,35 @@ class TestExchangeOrderBuilderV1CTF(TestCase):
             signed.signature,
             "0x302cd9abd0b5fcaa202a344437ec0b6660da984e24ae9ad915a592a90facf5a51bb8a873cd8d270f070217fea1986531d5eec66f1162a81f66e026db653bf7ce1c",
         )
+        self.assertEqual(
+            signed.order_hash,
+            "0x02ca1d1aa31103804173ad1acd70066cb6c1258a4be6dada055111f9a7ea4e55",
+        )
+        self.assertNotIn(
+            "order_hash", order_to_json_v1(signed, "owner", "GTC")["order"]
+        )
+
+    def test_build_signed_order_encodes_typed_data_once(self):
+        from py_clob_client_v2.order_utils import exchange_order_builder_v1 as module
+
+        with (
+            patch.object(
+                module,
+                "encode_typed_data",
+                wraps=module.encode_typed_data,
+            ) as encode,
+            patch.object(
+                module,
+                "_hash_message",
+                wraps=module._hash_message,
+            ) as duplicate_hash,
+        ):
+            signed = self.builder.build_signed_order(_ORDER_DATA)
+
+        self.assertTrue(signed.order_hash.startswith("0x"))
+        encode.assert_called_once()
+        duplicate_hash.assert_not_called()
+
 
 class TestExchangeOrderBuilderV1NegRisk(TestCase):
     """Tests against the Neg Risk CTF Exchange."""

--- a/tests/order_utils/test_exchange_order_builder_v2.py
+++ b/tests/order_utils/test_exchange_order_builder_v2.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+from unittest.mock import patch
 
 from py_clob_client_v2.config import get_contract_config
 from py_clob_client_v2.constants import AMOY, BYTES32_ZERO
@@ -6,7 +7,10 @@ from py_clob_client_v2.order_utils.exchange_order_builder_v2 import (
     ORDER_TYPE_STRING,
     ExchangeOrderBuilderV2,
 )
-from py_clob_client_v2.order_utils.model.order_data_v2 import OrderDataV2
+from py_clob_client_v2.order_utils.model.order_data_v2 import (
+    OrderDataV2,
+    order_to_json_v2,
+)
 from py_clob_client_v2.order_utils.model.side import Side
 from py_clob_client_v2.order_utils.model.signature_type_v2 import SignatureTypeV2
 from py_clob_client_v2.signer import Signer
@@ -44,6 +48,24 @@ def _poly_1271_order_data() -> OrderDataV2:
         takerAmount="50000000",
         side=Side.BUY,
         signatureType=SignatureTypeV2.POLY_1271,
+        timestamp=FIXED_TIMESTAMP,
+        metadata=BYTES32_ZERO,
+        builder=BYTES32_ZERO,
+    )
+
+
+def _eoa_signed_order_data(signature_type: SignatureTypeV2) -> OrderDataV2:
+    maker = (
+        SIGNER.address() if signature_type == SignatureTypeV2.EOA else DEPOSIT_WALLET
+    )
+    return OrderDataV2(
+        maker=maker,
+        signer=SIGNER.address(),
+        tokenId="1234",
+        makerAmount="100000000",
+        takerAmount="50000000",
+        side=Side.BUY,
+        signatureType=signature_type,
         timestamp=FIXED_TIMESTAMP,
         metadata=BYTES32_ZERO,
         builder=BYTES32_ZERO,
@@ -127,3 +149,64 @@ class TestExchangeOrderBuilderV2CTF(TestCase):
         self.assertEqual(signed.signer, DEPOSIT_WALLET)
         self.assertEqual(signed.signatureType, SignatureTypeV2.POLY_1271)
         self.assertEqual(signed.signature, EXPECTED_POLY_1271_SIGNATURE)
+        self.assertEqual(
+            signed.order_hash,
+            "0x2afca94626db91b2d556c351584a4cd93e13da32e377dc48c7983e43afa5ab47",
+        )
+        self.assertNotIn(
+            "order_hash", order_to_json_v2(signed, "owner", "GTC")["order"]
+        )
+
+    def test_build_signed_order_poly_1271_encodes_typed_data_once(self):
+        from py_clob_client_v2.order_utils import exchange_order_builder_v2 as module
+
+        with (
+            patch.object(
+                module,
+                "encode_typed_data",
+                wraps=module.encode_typed_data,
+            ) as encode,
+            patch.object(
+                module,
+                "_hash_message",
+                wraps=module._hash_message,
+            ) as order_hash,
+        ):
+            signed = self.builder.build_signed_order(_poly_1271_order_data())
+
+        self.assertTrue(signed.order_hash.startswith("0x"))
+        encode.assert_called_once()
+        order_hash.assert_called_once()
+
+    def test_build_signed_eoa_family_orders_carry_hash_from_one_encode(self):
+        from py_clob_client_v2.order_utils import exchange_order_builder_v2 as module
+
+        for signature_type in (
+            SignatureTypeV2.EOA,
+            SignatureTypeV2.POLY_PROXY,
+            SignatureTypeV2.POLY_GNOSIS_SAFE,
+        ):
+            with self.subTest(signature_type=signature_type):
+                with (
+                    patch.object(
+                        module,
+                        "encode_typed_data",
+                        wraps=module.encode_typed_data,
+                    ) as encode,
+                    patch.object(
+                        module,
+                        "_hash_message",
+                        wraps=module._hash_message,
+                    ) as duplicate_hash,
+                ):
+                    signed = self.builder.build_signed_order(
+                        _eoa_signed_order_data(signature_type)
+                    )
+
+                typed_data = self.builder.build_order_typed_data(signed)
+                self.assertEqual(
+                    signed.order_hash,
+                    self.builder.build_order_hash(typed_data),
+                )
+                encode.assert_called_once()
+                duplicate_hash.assert_not_called()

--- a/tests/test_client_order_metadata_warmup.py
+++ b/tests/test_client_order_metadata_warmup.py
@@ -1,0 +1,97 @@
+from unittest import TestCase
+
+from py_clob_client_v2 import ClobClient, MarketOrderArgsV2, OrderArgsV2
+from py_clob_client_v2.endpoints import (
+    GET_BUILDER_FEE_RATE,
+    GET_CLOB_MARKET,
+    GET_FEE_RATE,
+    VERSION,
+)
+
+
+HOST = "https://clob.example.com"
+CHAIN_ID = 80002
+PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+CONDITION_ID = "0x" + "ab" * 32
+TOKEN_IDS = ("1234", "5678")
+BUILDER_CODE = "0x" + "12" * 32
+
+
+def _market_info() -> dict:
+    return {
+        "t": [{"t": token_id} for token_id in TOKEN_IDS],
+        "mts": "0.01",
+        "nr": False,
+        "fd": {"r": 0.03, "e": 1.0},
+    }
+
+
+class TestClientOrderMetadataWarmup(TestCase):
+    def setUp(self):
+        self.client = ClobClient(host=HOST, chain_id=CHAIN_ID, key=PRIVATE_KEY)
+        self.calls = []
+
+    def _install_responses(self, version: int) -> None:
+        def fake_get(endpoint, headers=None, data=None, params=None):
+            del headers, data, params
+            self.calls.append(endpoint)
+            if endpoint == f"{HOST}{GET_CLOB_MARKET}{CONDITION_ID}":
+                return _market_info()
+            if endpoint == f"{HOST}{VERSION}":
+                return {"version": version}
+            if endpoint.startswith(f"{HOST}{GET_FEE_RATE}"):
+                return {"base_fee": 100}
+            if endpoint == f"{HOST}{GET_BUILDER_FEE_RATE}{BUILDER_CODE}":
+                return {
+                    "builder_maker_fee_rate_bps": 0,
+                    "builder_taker_fee_rate_bps": 25,
+                }
+            self.fail(f"unexpected GET {endpoint}")
+
+        self.client._get = fake_get
+
+    def test_successful_v2_warmup_removes_metadata_rest_from_first_orders(self):
+        self._install_responses(version=2)
+        self.client.warm_up_order_metadata(CONDITION_ID, builder_code=BUILDER_CODE)
+        self.calls.clear()
+
+        limit_order = self.client.create_order(
+            OrderArgsV2(
+                token_id=TOKEN_IDS[0],
+                price=0.5,
+                size=10,
+                side="BUY",
+            )
+        )
+        market_order = self.client.create_market_order(
+            MarketOrderArgsV2(
+                token_id=TOKEN_IDS[1],
+                amount=10,
+                side="BUY",
+                price=0.5,
+                user_usdc_balance=100,
+                builder_code=BUILDER_CODE,
+            )
+        )
+
+        self.assertEqual(self.calls, [])
+        self.assertTrue(limit_order.order_hash.startswith("0x"))
+        self.assertTrue(market_order.order_hash.startswith("0x"))
+
+    def test_successful_v1_warmup_caches_each_token_fee_cap(self):
+        self._install_responses(version=1)
+        self.client.warm_up_order_metadata(CONDITION_ID)
+        self.calls.clear()
+
+        signed_order = self.client.create_order(
+            OrderArgsV2(
+                token_id=TOKEN_IDS[0],
+                price=0.5,
+                size=10,
+                side="BUY",
+            )
+        )
+
+        self.assertEqual(self.calls, [])
+        self.assertEqual(signed_order.feeRateBps, "100")
+        self.assertTrue(signed_order.order_hash.startswith("0x"))

--- a/tests/test_client_order_metadata_warmup.py
+++ b/tests/test_client_order_metadata_warmup.py
@@ -53,6 +53,11 @@ class TestClientOrderMetadataWarmup(TestCase):
     def test_successful_v2_warmup_removes_metadata_rest_from_first_orders(self):
         self._install_responses(version=2)
         self.client.warm_up_order_metadata(CONDITION_ID, builder_code=BUILDER_CODE)
+        self.client.warm_up_order_metadata(CONDITION_ID, builder_code=BUILDER_CODE)
+        self.assertEqual(
+            self.calls.count(f"{HOST}{GET_BUILDER_FEE_RATE}{BUILDER_CODE}"),
+            1,
+        )
         self.calls.clear()
 
         limit_order = self.client.create_order(


### PR DESCRIPTION
## Summary

- add a public `warm_up_order_metadata` API so callers can populate order-construction metadata before latency-sensitive order creation
- expose the EIP-712 hash already produced while signing on `SignedOrderV1` and `SignedOrderV2`
- preserve V1, V2 EOA/proxy/safe, and POLY_1271 signatures and keep `order_hash` out of submitted JSON

## Why

Order creation may otherwise perform tick-size, negative-risk, fee, version, and builder-fee REST lookups on first use. Consumers that need the venue order ID also currently rebuild and hash the same typed data after signing. This gives callers public, dependency-owned APIs for both optimizations without copying private internals.

## Tests

- `python -m pytest -q` — 232 passed, 15 subtests passed
- regressions prove warmed V1/V2 first orders issue zero metadata GETs
- regressions prove each signature path encodes/hashes typed order data once and retains exact signature/hash compatibility
- regressions prove `order_hash` is excluded from the order wire payload

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance and API surface additions on order construction; signing semantics and wire payloads are preserved with regression tests.
> 
> **Overview**
> Adds **`warm_up_order_metadata(condition_id, builder_code?)`** so callers can prefetch CLOB market info (tick size, neg risk, fee metadata), V1 per-token fee caps, and optional builder fee rates before latency-sensitive **`create_order`** / **`create_market_order`** calls. Builder fee loading is centralized in **`__load_builder_fee_rate`**, reused by warmup and the existing lazy cache path.
> 
> **Signed orders** now carry an **`order_hash`** field on **`SignedOrderV1`** and **`SignedOrderV2`**, populated from the same EIP-712 encode/sign step via **`_build_order_signature_and_hash`** (one **`encode_typed_data`** per build for EOA-style paths; POLY_1271 still hashes once for the hash). **`order_to_json_v1` / `order_to_json_v2`** do not send **`order_hash`** on the wire.
> 
> Tests cover warmup avoiding metadata GETs on first orders, stable signature/hash values, single-encode behavior, and JSON exclusion of **`order_hash`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 905aae8ec0ea74711d6a57cf6ca3ed3ad029d1a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->